### PR TITLE
Fix bugs with deleting causing link to be clicked

### DIFF
--- a/client/components/common/DeleteCustomSetModal.tsx
+++ b/client/components/common/DeleteCustomSetModal.tsx
@@ -35,26 +35,38 @@ const DeleteCustomSetModal: React.FC<Props> = ({
   });
   const router = useRouter();
 
-  const onDelete = React.useCallback(async () => {
-    const { data } = await deleteMutate();
-    onCancel();
-    if (data?.deleteCustomSet?.ok) {
-      if (customSetId === router.query.customSetId) {
-        router.push('/', '/', { shallow: true });
+  const onDelete = React.useCallback(
+    async (e: React.MouseEvent<HTMLElement>) => {
+      e.stopPropagation();
+      const { data } = await deleteMutate();
+      onCancel();
+      if (data?.deleteCustomSet?.ok) {
+        if (customSetId === router.query.customSetId) {
+          router.push('/', '/', { shallow: true });
+        }
+        notification.success({
+          message: t('SUCCESS'),
+          description: t('DELETE_BUILD_SUCCESS'),
+        });
       }
-      notification.success({
-        message: t('SUCCESS'),
-        description: t('DELETE_BUILD_SUCCESS'),
-      });
-    }
-  }, [deleteMutate, router, onCancel, customSetId]);
+    },
+    [deleteMutate, router, onCancel, customSetId],
+  );
+
+  const onCancelClick = React.useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      e.stopPropagation();
+      onCancel();
+    },
+    [onCancel],
+  );
 
   return (
     <Modal
       visible={visible}
       title={t('DELETE_BUILD')}
       onOk={onDelete}
-      onCancel={onCancel}
+      onCancel={onCancelClick}
       confirmLoading={deleteLoading}
       okButtonProps={{ danger: true }}
       okText={t('DELETE')}

--- a/client/components/common/EquippedItemWithStats.tsx
+++ b/client/components/common/EquippedItemWithStats.tsx
@@ -86,6 +86,7 @@ const EquippedItemWithStats: React.FC<Props> = ({
   const onDelete = React.useCallback(
     (e: React.SyntheticEvent<HTMLElement>) => {
       e.stopPropagation();
+      e.preventDefault();
       if (deleteItem) {
         deleteItem();
       }

--- a/client/components/common/MyBuilds.tsx
+++ b/client/components/common/MyBuilds.tsx
@@ -250,6 +250,7 @@ const MyBuilds: React.FC<Props> = ({ onClose }) => {
                       }}
                       onClick={(e: React.MouseEvent<HTMLDivElement>) => {
                         e.stopPropagation();
+                        e.preventDefault();
                         setCustomSetIdToDelete(node.id);
                         setDeleteModalVisible(true);
                       }}


### PR DESCRIPTION
Because of a recent change adding anchor tags to links to improve accessibility, nested buttons (deleting an item or deleting a build) would cause the links to be clicked and followed, causing bugs. This PR fixes this issue.