### PR TITLE
Fix meta image change to work with new shorter stored URLs

### DIFF
--- a/client/common/utils.tsx
+++ b/client/common/utils.tsx
@@ -1395,11 +1395,11 @@ export const getCustomSetMetaImage = (customSet?: CustomSet | null) => {
   }
   return `https://32kom7xq5i.execute-api.us-east-2.amazonaws.com/${encodeURIComponent(
     customSet.name || 'Untitled',
-  )}?${customSet.equippedItems
+  )}?${[...customSet.equippedItems]
     .sort((ei1, ei2) => ei1.slot.order - ei2.slot.order)
     .map((ei) => {
       const { imageUrl } = ei.item;
-      const match = imageUrl.match(/\/item\/(\d+)\.png/);
+      const match = imageUrl.match(/item\/(\d+)\.png/);
       if (match && match[1]) {
         return match[1];
       }


### PR DESCRIPTION
#237 broke build previews because it expected a slash before the image URLs which didn't exist - this fixes that.