### PR TITLE
Item stat fixes

### DIFF
--- a/server/app/database/data/buffs.json
+++ b/server/app/database/data/buffs.json
@@ -1781,16 +1781,6 @@
       ]
     },
     {
-      "name": "Ebony Dofus",
-      "buffs": [
-        {
-          "stat": "% Final Damage",
-          "incrementBy": 2,
-          "maxStacks": 5
-        }
-      ]
-    },
-    {
       "name": "Turquoise Dofus",
       "buffs": [
         {

--- a/server/app/database/data/items.json
+++ b/server/app/database/data/items.json
@@ -36516,12 +36516,12 @@
       {
         "stat": "Pushback Resistance",
         "minStat": null,
-        "maxStat": 60
+        "maxStat": 80
       }
     ],
     "customStats": {
       "en": [
-        "Adds 150 shield points if the owner is moved by pushing, attraction, place switching or being carried by a Pandawa.\nOnly enemies can trigger this effect."
+        "Adds 150 shield points if the owner suffers pushback damage or is moved via pushing, attraction, position switching, teleportation, an Eliotrope portal, or being carried by a Pandawa.\n\nThe effect can only be triggered by enemies, and the shield can stack 2 times max."
       ],
       "fr": [
         "Ajoute 150 points de bouclier si le propriétaire est déplacé via une poussée, une attirance, un échange de position ou porté par un Pandawa.\nSeuls les ennemis peuvent déclencher cet effet."

--- a/server/app/database/data/items.json
+++ b/server/app/database/data/items.json
@@ -89013,6 +89013,11 @@
         "stat": "AP Reduction",
         "minStat": null,
         "maxStat": 6
+      },
+      {
+        "stat": "MP Parry",
+        "minStat": null,
+        "maxStat": -6
       }
     ],
     "customStats": {},


### PR DESCRIPTION
fixed some items that had outdated stats.
- removed ebony final damage buff
- fixed lavasmith pb resistance and english effect description
- fixed minor paralyzer trophy's negative mp parry