### PR TITLE
adding linear damage stat

### DIFF
--- a/client/common/constants.ts
+++ b/client/common/constants.ts
@@ -77,6 +77,7 @@ export const classicStatGroups = [
   [Stat.DODGE, Stat.LOCK],
   [Stat.AP_PARRY, Stat.AP_REDUCTION, Stat.MP_PARRY, Stat.MP_REDUCTION],
   [
+    Stat.DAMAGE,
     Stat.NEUTRAL_DAMAGE,
     Stat.EARTH_DAMAGE,
     Stat.FIRE_DAMAGE,

--- a/client/common/utils.tsx
+++ b/client/common/utils.tsx
@@ -1101,28 +1101,27 @@ export const statCalculators: { [key: string]: StatCalculator } = {
       : 0,
   [Stat.NEUTRAL_DAMAGE]: (statsFromCustomSet) =>
     statsFromCustomSet
-      ? getStatWithDefault(statsFromCustomSet, Stat.DAMAGE) +
-        getStatWithDefault(statsFromCustomSet, Stat.NEUTRAL_DAMAGE)
+      ? getStatWithDefault(statsFromCustomSet, Stat.NEUTRAL_DAMAGE)
       : 0,
   [Stat.EARTH_DAMAGE]: (statsFromCustomSet) =>
     statsFromCustomSet
-      ? getStatWithDefault(statsFromCustomSet, Stat.DAMAGE) +
-        getStatWithDefault(statsFromCustomSet, Stat.EARTH_DAMAGE)
+      ? getStatWithDefault(statsFromCustomSet, Stat.EARTH_DAMAGE)
       : 0,
   [Stat.FIRE_DAMAGE]: (statsFromCustomSet) =>
     statsFromCustomSet
-      ? getStatWithDefault(statsFromCustomSet, Stat.DAMAGE) +
-        getStatWithDefault(statsFromCustomSet, Stat.FIRE_DAMAGE)
+      ? getStatWithDefault(statsFromCustomSet, Stat.FIRE_DAMAGE)
       : 0,
   [Stat.WATER_DAMAGE]: (statsFromCustomSet) =>
     statsFromCustomSet
-      ? getStatWithDefault(statsFromCustomSet, Stat.DAMAGE) +
-        getStatWithDefault(statsFromCustomSet, Stat.WATER_DAMAGE)
+      ? getStatWithDefault(statsFromCustomSet, Stat.WATER_DAMAGE)
       : 0,
   [Stat.AIR_DAMAGE]: (statsFromCustomSet) =>
     statsFromCustomSet
-      ? getStatWithDefault(statsFromCustomSet, Stat.DAMAGE) +
-        getStatWithDefault(statsFromCustomSet, Stat.AIR_DAMAGE)
+      ? getStatWithDefault(statsFromCustomSet, Stat.AIR_DAMAGE)
+      : 0,
+  [Stat.DAMAGE]: (statsFromCustomSet) =>
+    statsFromCustomSet
+      ? getStatWithDefault(statsFromCustomSet, Stat.DAMAGE)
       : 0,
   [Stat.PODS]: (statsFromCustomSet) =>
     1000 +

--- a/client/components/desktop/ClassicRightColumnStats.tsx
+++ b/client/components/desktop/ClassicRightColumnStats.tsx
@@ -38,6 +38,7 @@ const ClassicRightColumnStats: React.FC<Props> = ({ openBuffModal }) => {
       />
       <StatTable
         group={[
+          Stat.DAMAGE,
           Stat.NEUTRAL_DAMAGE,
           Stat.EARTH_DAMAGE,
           Stat.FIRE_DAMAGE,

--- a/client/components/desktop/SetBuilder.tsx
+++ b/client/components/desktop/SetBuilder.tsx
@@ -42,6 +42,7 @@ const statGroups = [
   [Stat.DODGE, Stat.LOCK],
   [Stat.AP_PARRY, Stat.AP_REDUCTION, Stat.MP_PARRY, Stat.MP_REDUCTION],
   [
+    Stat.DAMAGE,
     Stat.NEUTRAL_DAMAGE,
     Stat.EARTH_DAMAGE,
     Stat.FIRE_DAMAGE,


### PR DESCRIPTION
re-do of #317 with exact same changes, see screenshots in that PR. I made some mistakes on my local git and inadvertently cancelled that PR.

Makes the "Damage" stat calculate and display separate from the elemental damage stats.