### PR TITLE
Item suggestions bugfix

### DIFF
--- a/client/components/common/ItemSelector.tsx
+++ b/client/components/common/ItemSelector.tsx
@@ -49,8 +49,9 @@ const ItemSelector: React.FC<Props> = ({
       variables: {
         first: PAGE_SIZE,
         filters: queryFilters,
-        customSetId: customSet?.id,
         itemSlotId: selectedItemSlot?.id,
+        equippedItemIds: customSet?.equippedItems.map((ei) => ei.id) ?? [],
+        level: customSet?.level ?? 200,
       },
     },
   );

--- a/client/graphql/queries/__generated__/items.ts
+++ b/client/graphql/queries/__generated__/items.ts
@@ -208,6 +208,7 @@ export interface itemsVariables {
   first: number;
   after?: string | null;
   filters: ItemFilters;
-  customSetId?: any | null;
   itemSlotId?: any | null;
+  equippedItemIds: any[];
+  level: number;
 }

--- a/client/graphql/queries/items.graphql
+++ b/client/graphql/queries/items.graphql
@@ -4,8 +4,9 @@ query items(
   $first: Int!
   $after: String
   $filters: ItemFilters!
-  $customSetId: UUID
   $itemSlotId: UUID
+  $equippedItemIds: [UUID!]!
+  $level: Int!
 ) {
   items(first: $first, after: $after, filters: $filters) {
     edges {
@@ -19,7 +20,11 @@ query items(
     }
   }
 
-  itemSuggestions(customSetId: $customSetId, itemSlotId: $itemSlotId) {
+  itemSuggestions(
+    equippedItemIds: $equippedItemIds
+    itemSlotId: $itemSlotId
+    level: $level
+  ) {
     ...item
   }
 }


### PR DESCRIPTION
This PR fixes caching issues where the previous version of this was making requests with a custom set ID, so it would be cached even as the custom set changes. An example of where this would be a bad user experience is if someone equips a hat for an INT set, then tries to look for cloaks, loading the item suggestions with the INT hat. The user then decides they want a chance set, replaces the hat with a chance hat, then searches for cloaks again, and the user gets the cached query with the INT hat.