### PR TITLE
Docker readme + tiltfile improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Make sure .sh files check out with unix line endings (LF, not CRLF)
+*.sh text eol=lf
+*.py text eol=lf

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please come give us a try at https://dofuslab.io!
 
 ---
 
-<details><summary><b>Project setup</b></summary>
+<details><summary><b>Project setup (manual)</b></summary>
 <p>
 
 ## Initial
@@ -107,8 +107,77 @@ Open http://dev.localhost:3000/ and test away!
 
 ---
 
-<details><summary><b>Making changes</b></summary>
+<details><summary><b>Project setup (docker)</b></summary>
 <p>
+
+## Installing software
+
+To get started, you'll need to install [Docker Desktop](https://www.docker.com/products/docker-desktop/), and optionally (but highly recommended) [Tilt](https://docs.tilt.dev/install.html).
+
+Note that you may need to configure your git client to check out "as-is" to avoid converting scripts to CRLF, which will result in errors like:
+
+```bash
+dofuslab@ac1658cacb7a:~/oneoff$ ./setup_db.sh
+bash: ./setup_db.sh: /bin/sh^M: bad interpreter: No such file or directory
+```
+
+## Running the development environment (Tilt)
+
+Once you have Docker Desktop and Tilt installed, you can run the Dofuslab environment by simply opening a terminal to the project directory, and running:
+
+```bash
+$ tilt up
+```
+
+This should result in some messages that look like:
+
+```bash
+$ tilt up
+Tilt started on http://localhost:10350/
+v0.30.7, built 2022-08-12
+
+(space) to open the browser
+(s) to stream logs (--stream=true)
+(t) to open legacy terminal mode (--legacy=true)
+(ctrl-c) to exit
+```
+
+At this point, you can press the spacebar to open Tilt in the browser to see service status and logs (or `s` to stream logs, etc). Dofuslab should now be building, and doing most of the steps in the manual setup section automatically.
+
+It'll probably take a few minutes to build the containers the first time, due to how big the client and server containers are. 
+
+If you only have Docker and aren't using Tilt:
+
+```bash
+$ docker compose up -d
+```
+
+## Populate database
+
+Once you have the docker compose/tilt environment running, you need to get the database populated.
+
+You can do this several ways. You can either run:
+
+```bash
+$ docker compose exec server /home/dofuslab/oneoff/setup_db.sh
+```
+
+Note that re-running this action can create duplicate items in the database, so just running it once is recommended. If you mess up your database, it's simple to reinitialize it. The simplest way is to bring your environment down (`tilt down`), and remove the postgres volume:
+
+```bash
+$ docker volume rm dofuslab_pgdata
+```
+
+Once you have your database populated, you should be able to access your development Dofuslab instance at http://localhost:3000/.
+
+</p>
+</details>
+
+---
+
+<details><summary><b>Making changes (manual)</b></summary>
+<p>
+
 
 ## Update database schema
 
@@ -181,5 +250,35 @@ $ python -m oneoff.sync_item
 </details>
 
 ---
+
+<details><summary><b>Making changes (Tilt)</b></summary>
+<p>
+
+For most things, Tilt should automatically update when files are changed. If things don't update correctly, you can `docker compose exec` scripts on the appropriate containers to update things. For instance:
+```bash
+$ cd server
+$ flask db migrate
+```
+...becomes:
+```bash
+$ docker compose exec server flask db migrate
+```
+
+That said, these updates should (for the most part) happen automatically!
+
+As of time of this writing, it will be necessary to sync items (and such) to the database when changes are made to those json files. I recommend having a shell opened in the server container:
+
+```bash
+$ docker compose exec -it server /bin/bash
+```
+
+...and following the sync instructions in the "manual" section. For example:
+
+```bash
+$ python -m oneoff.sync_item
+```
+
+</p>
+</details>
 
 [Join us on Discord](https://discord.gg/S4TvSfa) | [Buy us a coffee](https://www.buymeacoffee.com/dofuslab)

--- a/Tiltfile
+++ b/Tiltfile
@@ -45,10 +45,11 @@ docker_build(
 
 dc_resource('redis', labels=["database"])
 dc_resource('postgres', labels=["database"])
-dc_resource('server', labels=["server"], links = ["http://localhost:5000/api/graphql"])
-dc_resource('client', labels=["client"])
+dc_resource('server', labels=["server"], links = ["http://dev.localhost:5000/api/graphql"])
+dc_resource('client', labels=["client"], links = ["http://dev.localhost:3000/"])
 
-local_resource("setup-db", cmd="docker compose exec server /home/dofuslab/oneoff/setup_db.sh", auto_init=False, labels=['utilities'])
+local_resource("setup-db", cmd="./db/reset-db.sh", cmd_bat="cd db && reset-db.bat", auto_init=False, labels=['utilities'], trigger_mode=TRIGGER_MODE_MANUAL)
+
 # Run local commands
 #   Local commands can be helpful for one-time tasks like installing
 #   project prerequisites. They can also manage long-lived processes

--- a/Tiltfile
+++ b/Tiltfile
@@ -38,6 +38,24 @@ docker_build(
                      './server/app/translations/de/LC_MESSAGES/messages.po',
                      './server/app/translations/it/LC_MESSAGES/messages.po',
                      './server/app/translations/pt/LC_MESSAGES/messages.po']),
+        # info on database live update triggers:
+        # https://discord.com/channels/644349465859325972/705459723608260649/1006971343767609404
+        # per Germy:
+        # sync_buff => buffs.json
+        # sync_class => spells.json, buffs.json
+        # sync_custom_set_tag => custom_set_tags.json
+        # sync_item => items.json, pets.json, weapons.json, mounts.json, rhineetles.json
+        # sync_item_type => item_types.json
+        # sync_set => sets.json
+        # sync_spell => spells.json
+        # run('python -m /home/dofuslab/oneoff/sync_buff', trigger='./app/database/data/buffs.json'),
+        # run('python -m /home/dofuslab/oneoff/sync_class', trigger=['./app/database/data/buffs.json', './app/database/data/spells.json']),
+        # run('python -m /home/dofuslab/oneoff/sync_custom_set_tag', trigger='./app/database/data/custom_set_tags.json'),
+        # run('python -m /home/dofuslab/oneoff/sync_item', trigger=['./app/database/data/items.json', './app/database/data/pets.json', './app/database/data/weapons.json', './app/database/data/mounts.json', './app/database/data/rhineetles.json']),
+        # run('python -m /home/dofuslab/oneoff/sync_item_type', trigger='./app/database/data/item_types.json'),
+        # run('python -m /home/dofuslab/oneoff/sync_set', trigger='./app/database/data/sets.json'),
+        # run('python -m /home/dofuslab/oneoff/sync_spell', trigger='./app/database/data/spells.json'),
+        # we don't really need to restart the container for most of these, so it might make more sense to have local_resources down below?
         restart_container(),
     ],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -15,6 +15,7 @@ docker_build(
         sync('./client/.env.docker', '/home/dofuslab/.env'),
         sync('./client', '/home/dofuslab'),
         run('cd /home/dofuslab && yarn install', trigger=['./client/package.json', './client/yarn.lock']),
+        run('cd /home/dofuslab && yarn sync-i18n', trigger='/client/public/locales/en/'),
         # we might need to be slower on this one:
         run('cd /home/dofuslab && yarn apollo-codegen-docker', trigger=['./server/app/schema.py', './client/graphql/']),
         restart_container()
@@ -30,6 +31,13 @@ docker_build(
         sync('./server', '/home/dofuslab'),
         run('cd /home/dofuslab && pip install -r requirements.txt',
             trigger='./server/requirements.txt'),
+        run('cd /home/dofuslab && flask db migrate', trigger='./server/app/database/model_*.py'),
+        run('cd /home/dofuslab && make update-translations && make compile-translations', 
+            trigger=['./server/app/translations/es/LC_MESSAGES/messages.po',
+                     './server/app/translations/fr/LC_MESSAGES/messages.po',
+                     './server/app/translations/de/LC_MESSAGES/messages.po',
+                     './server/app/translations/it/LC_MESSAGES/messages.po',
+                     './server/app/translations/pt/LC_MESSAGES/messages.po']),
         restart_container(),
     ],
 )

--- a/db/reset-db.bat
+++ b/db/reset-db.bat
@@ -1,0 +1,4 @@
+docker compose exec postgres psql -U postgres -c "DROP DATABASE dofuslab WITH (FORCE);"
+docker compose exec postgres psql -U postgres -c "CREATE DATABASE dofuslab;"
+docker compose exec postgres /docker-entrypoint-initdb.d/01-init-psql.sh
+docker compose exec server /home/dofuslab/oneoff/setup_db.sh

--- a/db/reset-db.sh
+++ b/db/reset-db.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+docker compose exec postgres psql -U postgres -c "DROP DATABASE dofuslab WITH (FORCE);"
+docker compose exec postgres psql -U postgres -c "CREATE DATABASE dofuslab;"
+docker compose exec postgres /docker-entrypoint-initdb.d/01-init-psql.sh
+docker compose exec server /home/dofuslab/oneoff/setup_db.sh

--- a/server/.env.docker
+++ b/server/.env.docker
@@ -11,4 +11,4 @@ AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY
 SES_REGION=us-east-1
 SES_EMAIL_SOURCE=no-reply@dofuslab.io
-HOME_PAGE=http://dev.localhost:3000/
+HOME_PAGE=http://host.docker.internal:3000/

--- a/server/oneoff/setup_db.sh
+++ b/server/oneoff/setup_db.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+# set -e
 set -x
 
 flask db upgrade

--- a/server/oneoff/sync_buff.py
+++ b/server/oneoff/sync_buff.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+import json
+import os
 from app import session_scope
 from app.database.model_spell_translation import ModelSpellTranslation
 from app.database.model_spell_stats import ModelSpellStats
@@ -5,8 +9,6 @@ from app.database.model_item_translation import ModelItemTranslation
 from app.database.model_buff import ModelBuff
 from app.database.model_item import ModelItem
 from oneoff.enums import to_stat_enum
-import os
-import json
 
 root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/server/oneoff/sync_class.py
+++ b/server/oneoff/sync_class.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+import json
+import os
 from app import db
 from app import session_scope
 from app.database.model_item_translation import ModelItemTranslation
@@ -11,8 +15,6 @@ from app.database.model_buff import ModelBuff
 from oneoff.sync_spell import create_spell_stats
 import oneoff.sync_item
 import oneoff.sync_buff
-import json
-import os
 
 app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/server/oneoff/sync_custom_set_tag.py
+++ b/server/oneoff/sync_custom_set_tag.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import os
 from app import session_scope

--- a/server/oneoff/sync_item.py
+++ b/server/oneoff/sync_item.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import os
 from app import session_scope

--- a/server/oneoff/sync_item_type.py
+++ b/server/oneoff/sync_item_type.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import os
 from app import session_scope

--- a/server/oneoff/sync_name.py
+++ b/server/oneoff/sync_name.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import os
 from app import session_scope

--- a/server/oneoff/sync_set.py
+++ b/server/oneoff/sync_set.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import os
 from app import session_scope

--- a/server/oneoff/sync_spell.py
+++ b/server/oneoff/sync_spell.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import os
 from app import session_scope

--- a/server/oneoff/update_image_urls.py
+++ b/server/oneoff/update_image_urls.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+import json
+import os
 import re
 from app import app, db
 from app.database import base
@@ -7,8 +11,6 @@ from app.database.model_set import ModelSet
 from app.database.model_item import ModelItem
 from app.database.model_spell import ModelSpell
 from app.database.model_item_slot import ModelItemSlot
-import json
-import os
 
 app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 


### PR DESCRIPTION
The tiltfile should have better live updates for changes to schemas and such now, and automatic rebuilds for localization updates.

The manual has a bunch of new ::words:: for how to use Tilt and Docker and how to get started with them.

There are a number of other assorted improvements to style and preventing stubbed toes (particularly on Windows development environments).

I want to add an nginx frontend to this that we can use to proxy (and https upgrade) to our backends and set up publishing of ports just for the Tilt environment and such, but for the purposes of a development environment this should work fine.