### PR TITLE
User profile filtering via URL

### DIFF
--- a/client/common/types.ts
+++ b/client/common/types.ts
@@ -235,3 +235,7 @@ export type CustomSetMetadataAction =
   | { type: 'EDIT_NAME'; name: string }
   | { type: 'EDIT_LEVEL'; level: number }
   | { type: 'STOP_EDIT' };
+
+export type ProfileQueryParams = {
+  [key: string]: string | undefined;
+};

--- a/client/common/utils.tsx
+++ b/client/common/utils.tsx
@@ -102,6 +102,11 @@ import {
   EquippedItem,
 } from './type-aliases';
 import { prependDe } from './i18n-utils';
+import { classes } from 'graphql/queries/__generated__/classes';
+import { customSetTags } from 'graphql/queries/__generated__/customSetTags';
+
+import classesQuery from '../graphql/queries/classes.graphql';
+import customSetTagsQuery from '../graphql/queries/customSetTags.graphql';
 
 export const getImageUrl = (suffix: string) =>
   suffix.startsWith('https://')
@@ -1981,3 +1986,45 @@ export function slotToUrlString(itemSlot: EquippedItemSlot) {
 
   return name;
 }
+
+export const useProfileQueryParams = (isProfile: boolean) => {
+  const router = useRouter();
+  const {
+    search: routerSearch,
+    tags: routerTags,
+    class: routerClass,
+  } = router.query;
+
+  const { data: classData } = useQuery<classes>(classesQuery);
+  const { data: tagsData } = useQuery<customSetTags>(customSetTagsQuery);
+
+  const search = isProfile ? (routerSearch as string) || '' : '';
+
+  const classId = isProfile
+    ? classData?.classes.find((item) => item.enName === routerClass)?.id
+    : undefined;
+
+  const tagIds =
+    isProfile && routerTags
+      ? decodeURIComponent(routerTags as string)
+          .split(',')
+          .map((item) => {
+            const found = tagsData?.customSetTags.find(
+              (it) => it.enName === item,
+            );
+            if (!found) {
+              return;
+            } else {
+              return tagsData?.customSetTags.find((it) => it.enName === item)
+                ?.id;
+            }
+          })
+          .filter((item) => !!item)
+      : [];
+
+  return {
+    search,
+    class: classId,
+    tags: tagIds,
+  };
+};

--- a/client/components/common/BuildList.tsx
+++ b/client/components/common/BuildList.tsx
@@ -21,7 +21,9 @@ import {
   getImageUrl,
   navigateToNewCustomSet,
   antdSelectFilterOption,
+  useProfileQueryParams,
 } from 'common/utils';
+import { ProfileQueryParams } from 'common/types';
 import { createCustomSet } from 'graphql/mutations/__generated__/createCustomSet';
 import createCustomSetMutation from 'graphql/mutations/createCustomSet.graphql';
 import { useQuery, useMutation, useApolloClient } from '@apollo/client';
@@ -37,6 +39,8 @@ import { BUILD_LIST_PAGE_SIZE, DEBOUNCE_INTERVAL, mq } from 'common/constants';
 import { useDebounceCallback } from '@react-hook/debounce';
 import { customSetTags } from 'graphql/queries/__generated__/customSetTags';
 import customSetTagsQuery from 'graphql/queries/customSetTags.graphql';
+import { classes } from 'graphql/queries/__generated__/classes';
+import classesQuery from 'graphql/queries/classes.graphql';
 import DeleteCustomSetModal from './DeleteCustomSetModal';
 import ClassSelect from './ClassSelect';
 import BuildCard from './BuildCard';
@@ -52,6 +56,7 @@ interface Props {
   isEditable: boolean;
   getScrollParent?: () => HTMLElement | null;
   isMobile: boolean;
+  isProfile?: boolean;
 }
 
 const BuildList: React.FC<Props> = ({
@@ -60,8 +65,19 @@ const BuildList: React.FC<Props> = ({
   isEditable,
   getScrollParent,
   isMobile,
+  isProfile = false,
 }) => {
   const { t } = useTranslation('common');
+
+  const router = useRouter();
+
+  const {
+    search: defaultSearch,
+    tags: defaultTagIds,
+    class: defaultClassId,
+  } = useProfileQueryParams(isProfile);
+
+  const didMount = React.useRef(false);
 
   const [mutate, { loading: createLoading }] = useMutation<createCustomSet>(
     createCustomSetMutation,
@@ -78,11 +94,16 @@ const BuildList: React.FC<Props> = ({
     setDeleteModalVisible(false);
   }, []);
 
-  const [search, setSearch] = React.useState('');
+  const { data: classData } = useQuery<classes>(classesQuery);
+  const { data: tagsData } = useQuery<customSetTags>(customSetTagsQuery);
+
+  const [search, setSearch] = React.useState(defaultSearch);
+
   const [dofusClassId, setDofusClassId] = React.useState<string | undefined>(
-    undefined,
+    defaultClassId,
   );
-  const [tagIds, setTagIds] = React.useState<Array<string>>([]);
+
+  const [tagIds, setTagIds] = React.useState<Array<string>>(defaultTagIds);
 
   const handleSearchChange = React.useCallback(
     (searchValue: string) => {
@@ -95,6 +116,47 @@ const BuildList: React.FC<Props> = ({
     handleSearchChange,
     DEBOUNCE_INTERVAL,
   );
+
+  // Takes params from the router and filters them out so that the inherent username value is not in the address bar
+  // twice, also when values are undefined or empty strings. Returns a new object to use in formatQueryString.
+  const formatParams = (obj: ProfileQueryParams) =>
+    Object.entries(obj)
+      .filter(([, val]) => val !== undefined && val !== '' && val !== username)
+      .reduce((result, [key, val]) => {
+        result[key] = val;
+        return result;
+      }, {} as ProfileQueryParams);
+
+  const formatQueryString = () => {
+    const params = formatParams({
+      ...router.query,
+      search,
+      class: classData?.classes.find((item) => item.id === dofusClassId)
+        ?.enName,
+      tags: tagIds
+        .map(
+          (tagId) =>
+            tagsData?.customSetTags.find((tag) => tagId === tag.id)?.enName,
+        )
+        .join(','),
+    });
+
+    return !Object.keys(params).length
+      ? ''
+      : `?${Object.entries(params)
+          .map((item) => `${item[0]}=${item[1]}`)
+          .join('&')}`;
+  };
+
+  React.useEffect(() => {
+    if (!isProfile) {
+      return;
+    } else if (!didMount.current) {
+      didMount.current = true;
+    } else {
+      router.replace(`${username}${formatQueryString()}`);
+    }
+  }, [search, dofusClassId, tagIds]);
 
   const onSearch = React.useCallback(
     (changeEvent: React.ChangeEvent<HTMLInputElement>) => {
@@ -115,8 +177,6 @@ const BuildList: React.FC<Props> = ({
       filters: { search, defaultClassId: dofusClassId, tagIds },
     },
   });
-
-  const { data: tagsData } = useQuery<customSetTags>(customSetTagsQuery);
 
   const onLoadMore = React.useCallback(async () => {
     if (!userBuilds?.userByName?.customSets.pageInfo.hasNextPage) {
@@ -150,8 +210,6 @@ const BuildList: React.FC<Props> = ({
   );
 
   const theme = useTheme();
-
-  const router = useRouter();
 
   const onCreate = React.useCallback(async () => {
     const { data: resultData } = await mutate({
@@ -264,6 +322,7 @@ const BuildList: React.FC<Props> = ({
                 }}
                 onChange={onSearch}
                 placeholder={t('SEARCH')}
+                defaultValue={search}
                 onKeyDown={(e) => {
                   // prevents triggering SetBuilderKeyboardShortcuts
                   e.nativeEvent.stopPropagation();

--- a/client/components/common/BuildList.tsx
+++ b/client/components/common/BuildList.tsx
@@ -123,8 +123,11 @@ const BuildList: React.FC<Props> = ({
     Object.entries(obj)
       .filter(([, val]) => val !== undefined && val !== '' && val !== username)
       .reduce((result, [key, val]) => {
-        result[key] = val;
-        return result;
+        const newResult = {
+          ...result,
+          [key]: val,
+        };
+        return newResult;
       }, {} as ProfileQueryParams);
 
   const formatQueryString = () => {
@@ -151,7 +154,8 @@ const BuildList: React.FC<Props> = ({
   React.useEffect(() => {
     if (!isProfile) {
       return;
-    } else if (!didMount.current) {
+    }
+    if (!didMount.current) {
       didMount.current = true;
     } else {
       router.replace(`${username}${formatQueryString()}`);

--- a/client/components/common/UserProfile.tsx
+++ b/client/components/common/UserProfile.tsx
@@ -188,6 +188,7 @@ const UserProfile: React.FC<Props> = ({
           username={username}
           isEditable={isEditable}
           isMobile={false}
+          isProfile
         />
       </Media>
     </div>

--- a/client/graphql/queries/__generated__/customSetTags.ts
+++ b/client/graphql/queries/__generated__/customSetTags.ts
@@ -11,6 +11,7 @@ export interface customSetTags_customSetTags {
   __typename: "CustomSetTag";
   id: any;
   name: string;
+  enName: string;
   imageUrl: string;
 }
 

--- a/client/graphql/queries/customSetTags.graphql
+++ b/client/graphql/queries/customSetTags.graphql
@@ -2,6 +2,7 @@ query customSetTags {
   customSetTags {
     id
     name
+    enName
     imageUrl
   }
 }

--- a/server/app/schema.py
+++ b/server/app/schema.py
@@ -333,10 +333,20 @@ class CustomSetStats(SQLAlchemyObjectType):
 
 class CustomSetTag(SQLAlchemyObjectType):
     name = graphene.String(required=True)
+    en_name = graphene.String(required=True)
     image_url = graphene.String(required=True)
 
     def resolve_name(self, info):
         return g.dataloaders.get("custom_set_tag_translation_loader").load(self.uuid)
+    
+    def resolve_en_name(self, info):
+        query = db.session.query(ModelCustomSetTagTranslation)
+        return (
+            query.filter(ModelCustomSetTagTranslation.locale == 'en')
+            .filter(ModelCustomSetTagTranslation.custom_set_tag_id == self.uuid)
+            .one()
+            .name
+        )
 
     class Meta:
         model = ModelCustomSetTag


### PR DESCRIPTION
Implements filtering via query string in the URL.
- Edits schema so that tags also have an `enName` field.
- Formats URL when fields change.
- Handles errors by ignoring tags or class queries that don't exist.
- Adds isProfile field to BuildList to discern whether the change in the fields was inside a profile page or it's in the Layout drawer. The former doesn't trigger an URL change, the latter does. The property is also used so that the drawer doesn't receive the query params unnecessarily and wrongly filters the user's own builds.