### PR TITLE
Bugfix: Equip Set button creates a new set

### DIFF
--- a/client/components/desktop/BonusStats.tsx
+++ b/client/components/desktop/BonusStats.tsx
@@ -55,7 +55,9 @@ const BonusStats: React.FC<Props> = ({ customSet, isMobile, isClassic }) => {
   const contentRef = React.useRef<HTMLDivElement | null>(null);
 
   if (Object.values(setBonuses).length === 0) {
-    return isMobile || isClassic ? <EquipSetLink /> : null;
+    return isMobile || isClassic ? (
+      <EquipSetLink customSetId={customSet && customSet.id} />
+    ) : null;
   }
 
   const sortedSetBonuses = Object.values(setBonuses).sort(


### PR DESCRIPTION
There was an awkward middle between customSet being null (on page load for example when you're not on any set) - The button worked as intended, since there was no customSet.id to forward to the equip page.

The other end was, when you had a item set showing, and only when you had an item set showing, this component would forward the customSet.id to the equip button, because the instance in line 211 would be rendered, not this one  that is made in line 58. 

![image](https://user-images.githubusercontent.com/61996301/226601670-b9ff0765-d2da-4f82-88e0-3b55b71a4a30.png)

The awkward middle was this button being rendered and 100% of the times passing undefined when there were items equipped, but they did not belong to the same set 😅 .