### PR TITLE
2.70 sets and related changes

### DIFF
--- a/server/app/database/data/buffs.json
+++ b/server/app/database/data/buffs.json
@@ -1700,6 +1700,16 @@
           "maxStacks": 1
         }
       ]
+    },
+    {
+      "name": "Sylvan Dofus",
+      "buffs": [
+        {
+          "stat": "Power",
+          "incrementBy": 8,
+          "maxStacks": 20
+        }
+      ]
     }
   ]
 }

--- a/server/app/database/data/items.json
+++ b/server/app/database/data/items.json
@@ -22705,25 +22705,7 @@
     ],
     "customStats": {},
     "conditions": {
-      "conditions": {
-        "and": [
-          {
-            "stat": "INTELLIGENCE",
-            "operator": "<",
-            "value": 560
-          },
-          {
-            "stat": "CHANCE",
-            "operator": "<",
-            "value": 560
-          },
-          {
-            "stat": "AGILITY",
-            "operator": "<",
-            "value": 560
-          }
-        ]
-      },
+      "conditions": {},
       "customConditions": {}
     },
     "imageUrl": "item/1181.png"
@@ -28736,7 +28718,12 @@
       "conditions": {
         "and": [
           {
-            "stat": "AP",
+            "stat": "MP",
+            "operator": "<",
+            "value": 6
+          },
+          {
+            "stat": "MP",
             "operator": "<",
             "value": 12
           }
@@ -30539,6 +30526,11 @@
             "stat": "MP",
             "operator": "<",
             "value": 6
+          },
+          {
+            "stat": "MP",
+            "operator": "<",
+            "value": 12
           }
         ]
       },
@@ -31552,6 +31544,11 @@
             "stat": "MP",
             "operator": "<",
             "value": 6
+          },
+          {
+            "stat": "MP",
+            "operator": "<",
+            "value": 12
           }
         ]
       },
@@ -32680,7 +32677,12 @@
       "conditions": {
         "and": [
           {
-            "stat": "AP",
+            "stat": "MP",
+            "operator": "<",
+            "value": 6
+          },
+          {
+            "stat": "MP",
             "operator": "<",
             "value": 12
           }
@@ -33363,15 +33365,7 @@
     ],
     "customStats": {},
     "conditions": {
-      "conditions": {
-        "and": [
-          {
-            "stat": "AGILITY",
-            "operator": "<",
-            "value": 600
-          }
-        ]
-      },
+      "conditions": {},
       "customConditions": {}
     },
     "imageUrl": "item/11192.png"
@@ -33816,15 +33810,7 @@
     ],
     "customStats": {},
     "conditions": {
-      "conditions": {
-        "and": [
-          {
-            "stat": "INTELLIGENCE",
-            "operator": "<",
-            "value": 600
-          }
-        ]
-      },
+      "conditions": {},
       "customConditions": {}
     },
     "imageUrl": "item/16304.png"
@@ -34447,15 +34433,7 @@
     ],
     "customStats": {},
     "conditions": {
-      "conditions": {
-        "and": [
-          {
-            "stat": "STRENGTH",
-            "operator": "<",
-            "value": 600
-          }
-        ]
-      },
+      "conditions": {},
       "customConditions": {}
     },
     "imageUrl": "item/10204.png"
@@ -34825,15 +34803,7 @@
     ],
     "customStats": {},
     "conditions": {
-      "conditions": {
-        "and": [
-          {
-            "stat": "CHANCE",
-            "operator": "<",
-            "value": 600
-          }
-        ]
-      },
+      "conditions": {},
       "customConditions": {}
     },
     "imageUrl": "item/9228.png"
@@ -134443,5 +134413,52 @@
     "customStats": {},
     "conditions": { "conditions": {}, "customConditions": {} },
     "imageUrl": "item/9380.png"
+  },
+  {
+    "dofusID": "29134",
+    "name": {
+      "en": "Sylvan Dofus",
+      "fr": "Dofus Sylvestre",
+      "de": "Wald-Dofus",
+      "es": "Dofus silvestre",
+      "it": "[!] Sylvan Dofus",
+      "pt": "Dofus Silvestre"
+    },
+    "itemType": "Dofus",
+    "setID": null,
+    "level": 180,
+    "stats": [
+      {
+        "stat": "Range",
+        "minStat": null,
+        "maxStat": 2
+      }
+    ],
+    "customStats": {
+      "en": [
+        "For each MP used, the bearer gains 8 Power for 2 turns, stackable 20 times. If the bearer does not use any MP, they are healed for 10% of their HP at the end of their turn."
+      ],
+      "fr": [
+        "À chaque PM utilisé, le porteur gagne 8 Puissance pour 2 tours, cumulable 20 fois. Si au contraire il n'utilise aucun PM, il est soigné de 10% de ses PV à la fin de son tour.",
+        "Attitude Dofus Turquoise"
+      ],
+      "de": [
+        "[!] For each MP used, the bearer gains 8 Power for 2 turns, stackable 20 times. If the bearer does not use any MP, they are healed for 10% of their HP at the end of their turn."
+      ],
+      "es": [
+        "[!] For each MP used, the bearer gains 8 Power for 2 turns, stackable 20 times. If the bearer does not use any MP, they are healed for 10% of their HP at the end of their turn."
+      ],
+      "it": [
+        "[!] For each MP used, the bearer gains 8 Power for 2 turns, stackable 20 times. If the bearer does not use any MP, they are healed for 10% of their HP at the end of their turn."
+      ],
+      "pt": [
+        "[!] For each MP used, the bearer gains 8 Power for 2 turns, stackable 20 times. If the bearer does not use any MP, they are healed for 10% of their HP at the end of their turn."
+      ]
+    },
+    "conditions": {
+      "conditions": {},
+      "customConditions": {}
+    },
+    "imageUrl": "item/23036.png"
   }
 ]

--- a/server/app/database/data/pets.json
+++ b/server/app/database/data/pets.json
@@ -49,7 +49,7 @@
       "pt": "Kaniglups"
     },
     "itemType": "Pet",
-    "setID": "267",
+    "setID": null,
     "level": 80,
     "stats": [
       {
@@ -88,7 +88,7 @@
       "pt": "Bulbitoca"
     },
     "itemType": "Pet",
-    "setID": "268",
+    "setID": null,
     "level": 80,
     "stats": [
       {
@@ -127,7 +127,7 @@
       "pt": "Amiglurso"
     },
     "itemType": "Pet",
-    "setID": "266",
+    "setID": null,
     "level": 80,
     "stats": [
       {
@@ -166,7 +166,7 @@
       "pt": "Texofo"
     },
     "itemType": "Pet",
-    "setID": "269",
+    "setID": null,
     "level": 80,
     "stats": [
       {

--- a/server/app/database/data/sets.json
+++ b/server/app/database/data/sets.json
@@ -5,8 +5,8 @@
       "en": "Sinistrofu Set",
       "fr": "Panoplie du Sinistrofu",
       "de": "Sinistrofu-Set",
-      "es": "Set de buhotofu",
       "it": "Panoplia del Sinistrofu",
+      "es": "Set de buhotofu",
       "pt": "Conjunto do Sinistrofu"
     },
     "bonuses": {
@@ -22,30 +22,46 @@
           "altStat": null
         },
         {
-          "stat": "Pushback Resistance",
-          "value": 30,
+          "stat": "Fire Resistance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 150,
           "altStat": null
         }
       ],
       "3": [
-        {
-          "stat": "Chance",
-          "value": 50,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Critical Resistance",
           "value": 15,
           "altStat": null
         },
         {
-          "stat": "Pushback Resistance",
-          "value": 30,
+          "stat": "Chance",
+          "value": 50,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Fire Resistance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 150,
           "altStat": null
         }
       ]
@@ -57,8 +73,8 @@
       "en": "Bubotron Set",
       "fr": "Panoplie du Granduk",
       "de": "Obu-Bobub - Set",
-      "es": "Set de bubobubo",
       "it": "Panoplia del Guforeale",
+      "es": "Set de bubobubo",
       "pt": "Conjunto do Bububo"
     },
     "bonuses": {
@@ -72,27 +88,55 @@
           "stat": "Lock",
           "value": 15,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Range",
+          "value": -1,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 8,
+          "altStat": null
+        },
+        { "stat": "MP", "value": 1, "altStat": null }
       ],
       "3": [
+        {
+          "stat": "Range",
+          "value": -1,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 8,
+          "altStat": null
+        },
+        { "stat": "MP", "value": 1, "altStat": null },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Lock",
+          "value": 15,
+          "altStat": null
+        },
         {
           "stat": "Agility",
           "value": 50,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "% Fire Resistance",
+          "value": 8,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "% Water Resistance",
+          "value": 8,
           "altStat": null
         },
         {
-          "stat": "Lock",
-          "value": 15,
+          "stat": "% Air Resistance",
+          "value": 8,
           "altStat": null
         }
       ]
@@ -104,8 +148,8 @@
       "en": "Gein Set",
       "fr": "Panoplie de Gein",
       "de": "Gain-Set",
-      "es": "Set de Lonyon",
       "it": "Panoplia di Tramlock",
+      "es": "Set de Lonyon",
       "pt": "Conjunto do Gein"
     },
     "bonuses": {
@@ -122,19 +166,19 @@
         },
         {
           "stat": "Critical Damage",
-          "value": 10,
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 15,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Damage",
-          "value": 10,
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
@@ -143,8 +187,14 @@
           "altStat": null
         },
         {
-          "stat": "Strength",
+          "stat": "Critical Damage",
           "value": 40,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Dodge",
+          "value": 15,
           "altStat": null
         }
       ]
@@ -156,8 +206,8 @@
       "en": "Queen of Thieves Set",
       "fr": "Panoplie de la Reine des Voleurs",
       "de": "Set der Königin der Diebe",
-      "es": "Set de la Reina de los Ladrones",
       "it": "Panoplia della Regina dei Ladri",
+      "es": "Set de la Reina de los Ladrones",
       "pt": "Conjunto da Rainha dos Ladrões"
     },
     "bonuses": {
@@ -173,22 +223,7 @@
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Resistance",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Damage",
+          "stat": "Water Damage",
           "value": 20,
           "altStat": null
         },
@@ -198,55 +233,66 @@
           "altStat": null
         },
         {
-          "stat": "Water Damage",
+          "stat": "Earth Damage",
           "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 50,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Strength",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Resistance",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Damage",
-          "value": 20,
+          "stat": "Water Damage",
+          "value": 25,
           "altStat": null
         },
         {
           "stat": "Neutral Damage",
-          "value": 20,
+          "value": 25,
           "altStat": null
         },
         {
-          "stat": "Water Damage",
-          "value": 20,
+          "stat": "Earth Damage",
+          "value": 25,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Air Damage",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         }
       ]
@@ -258,57 +304,73 @@
       "en": "Rassler Set",
       "fr": "Panoplie du Katcheur",
       "de": "Wresseln-Set",
-      "es": "Set de luchador de presinkach",
       "it": "Panoplia del Restler",
+      "es": "Set de luchador de presinkach",
       "pt": "Conjunto do lutador de Ketch"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Vitality",
-          "value": 100,
+          "value": 300,
           "altStat": null
         },
         {
           "stat": "Strength",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Intelligence",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 30,
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 600,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 40,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Vitality",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
-          "value": 30,
+          "stat": "Agility",
+          "value": 60,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 30,
+          "value": 60,
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 30,
+          "stat": "Strength",
+          "value": 60,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Vitality",
+          "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 1000,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 40,
           "altStat": null
         }
       ]
@@ -320,26 +382,85 @@
       "en": "Harpiset",
       "fr": "Harpinoplie",
       "de": "Harpy-Set",
-      "es": "Set de arpilla",
       "it": "Panoplia Arpredona",
+      "es": "Set de arpilla",
       "pt": "Conjunto Harpilha"
     },
     "bonuses": {
       "2": [
+        { "stat": "MP", "value": 1, "altStat": null },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "MP",
+          "stat": "Dodge",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
           "value": 1,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 2, "altStat": null },
+        { "stat": "MP", "value": 1, "altStat": null },
         {
-          "stat": "AP",
+          "stat": "Dodge",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
           "value": 1,
           "altStat": null
         },
         {
-          "stat": "MP",
+          "stat": "Summons",
           "value": 1,
           "altStat": null
         }
@@ -352,30 +473,25 @@
       "en": "Catseye Set",
       "fr": "Panoplie du Chalœil",
       "de": "Maunzaug-Set",
-      "es": "Set de Miauvizor",
       "it": "Panoplia dello Stellaflip",
+      "es": "Set de Miauvizor",
       "pt": "Conjunto do Gatolho"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Strength",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 30,
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         },
         {
@@ -384,30 +500,26 @@
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 12,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Strength",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Intelligence",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 30,
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         },
         {
@@ -416,13 +528,28 @@
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Chance",
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 12,
           "altStat": null
         }
       ]
@@ -434,8 +561,8 @@
       "en": "Octoset",
       "fr": "Poulplie",
       "de": "Krakset",
-      "es": "Set pulpil",
       "it": "Polplia",
+      "es": "Set pulpil",
       "pt": "Polvunto"
     },
     "bonuses": {
@@ -451,20 +578,26 @@
           "altStat": null
         },
         {
+          "stat": "Lock",
+          "value": 15,
+          "altStat": null
+        },
+        {
           "stat": "AP Reduction",
-          "value": 5,
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Lock",
+          "value": 15,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "AP Reduction",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
         {
@@ -486,8 +619,8 @@
       "en": "Tal Kasha Set",
       "fr": "Panoplie de Tal Kasha",
       "de": "Tal Kashas Set",
-      "es": "Set de Tal Kasha",
       "it": "Panoplia di Tal Kasha",
+      "es": "Set de Tal Kasha",
       "pt": "Conjunto de Tal Kasha"
     },
     "bonuses": {
@@ -506,11 +639,17 @@
           "stat": "Critical Damage",
           "value": 15,
           "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 7,
+          "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Air Damage",
+          "stat": "Critical Damage",
           "value": 15,
           "altStat": null
         },
@@ -520,13 +659,13 @@
           "altStat": null
         },
         {
-          "stat": "Critical Damage",
+          "stat": "Air Damage",
           "value": 15,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "AP Reduction",
+          "value": 7,
           "altStat": null
         }
       ]
@@ -538,8 +677,8 @@
       "en": "Bleeding Heart Set",
       "fr": "Panoplie du Cœur Saignant",
       "de": "Set des Blutenden Herzens",
-      "es": "Set del Corazón Sangriento",
       "it": "Panoplia del Cuore Sanguinante",
+      "es": "Set del Corazón Sangriento",
       "pt": "Conjunto do Coração Sangrento"
     },
     "bonuses": {
@@ -547,6 +686,11 @@
         {
           "stat": "Critical Damage",
           "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 10,
           "altStat": null
         }
       ],
@@ -556,9 +700,10 @@
           "value": 20,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "MP Reduction",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -570,8 +715,8 @@
       "en": "Putrid Eye Set",
       "fr": "Panoplie de l'Œil Putride",
       "de": "Set des Eitrigen Auges",
-      "es": "Set del Ojo Putrefacto",
       "it": "Panoplia dell'Occhio Putrido",
+      "es": "Set del Ojo Putrefacto",
       "pt": "Conjunto do Olho Pútrido"
     },
     "bonuses": {
@@ -582,8 +727,18 @@
           "altStat": null
         },
         {
-          "stat": "Vitality",
-          "value": 150,
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         }
       ],
@@ -593,13 +748,19 @@
           "value": 1000,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Vitality",
-          "value": 150,
+          "stat": "MP Reduction",
+          "value": 10,
           "altStat": null
         },
         {
-          "stat": "AP",
+          "stat": "Dodge",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
           "value": 1,
           "altStat": null
         }
@@ -612,8 +773,8 @@
       "en": "Bethel Set",
       "fr": "Panoplie de Bethel",
       "de": "Bethels Set",
-      "es": "Set de Bethel",
       "it": "Panoplia di Bethel",
+      "es": "Set de Bethel",
       "pt": "Conjunto de Bethel"
     },
     "bonuses": {
@@ -627,12 +788,52 @@
           "stat": "Range",
           "value": 1,
           "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": -10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
+          "value": 1,
+          "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP Reduction",
+          "stat": "Lock",
+          "value": -10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
           "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
@@ -640,8 +841,14 @@
           "value": 1,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "AP",
+          "stat": "AP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
           "value": 1,
           "altStat": null
         }
@@ -654,57 +861,53 @@
       "en": "Chocomancer Set",
       "fr": "Panoplie des Chocomanciens",
       "de": "Schokomanten-Set",
-      "es": "Set de los chocomantes",
       "it": "Panoplia dei Cioccomanti",
+      "es": "Set de los chocomantes",
       "pt": "Conjunto dos Chocomantes"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Vitality",
-          "value": 100,
+          "value": 300,
           "altStat": null
         },
         {
           "stat": "Power",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Lock",
-          "value": 10,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
           "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 15,
           "altStat": null
         }
       ],
       "3": [
-        {
-          "stat": "Vitality",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Power",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Lock",
-          "value": 10,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "MP Reduction",
           "value": 10,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Lock",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 300,
           "altStat": null
         }
       ]
@@ -716,49 +919,75 @@
       "en": "Lunar Set",
       "fr": "Panoplie Lunaire",
       "de": "Mondset",
-      "es": "Set lunar",
       "it": "Panoplia Lunare",
+      "es": "Set lunar",
       "pt": "Conjunto Lunar"
     },
     "bonuses": {
       "2": [
         {
           "stat": "AP Reduction",
-          "value": 5,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
-          "value": 5,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 10,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "AP Reduction",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "MP Reduction",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Dodge",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Range",
           "value": 1,
           "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 50,
+          "altStat": null
         }
+      ],
+      "3": [
+        {
+          "stat": "Dodge",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 1000,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 100,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -820,8 +1049,8 @@
       "en": "Servitude Set",
       "fr": "Panoplie de Servitude",
       "de": "Knechtschaft-Set",
-      "es": "Set de Servidumbre",
       "it": "Panoplia di Servitù",
+      "es": "Set de Servidumbre",
       "pt": "Conjunto de Servidão"
     },
     "bonuses": {
@@ -835,6 +1064,11 @@
           "stat": "Pushback Resistance",
           "value": 50,
           "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 50,
+          "altStat": null
         }
       ],
       "3": [
@@ -844,12 +1078,13 @@
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Pushback Resistance",
+          "value": 50,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Pushback Resistance",
+          "stat": "Chance",
           "value": 50,
           "altStat": null
         }
@@ -862,8 +1097,8 @@
       "en": "Age-Old Set",
       "fr": "Panoplie Séculaire",
       "de": "Säkular-Set",
-      "es": "Set secular",
       "it": "Panoplia Secolare",
+      "es": "Set secular",
       "pt": "Conjunto Secular"
     },
     "bonuses": {
@@ -880,19 +1115,24 @@
         },
         {
           "stat": "Critical Damage",
-          "value": 10,
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Damage",
-          "value": 10,
+          "stat": "Intelligence",
+          "value": 50,
           "altStat": null
         },
         {
@@ -901,8 +1141,19 @@
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 50,
+          "stat": "Critical Damage",
+          "value": 15,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 20,
           "altStat": null
         }
       ]
@@ -914,57 +1165,83 @@
       "en": "Cryochrone Set",
       "fr": "Panoplie Cryochrone",
       "de": "Cryochron-Set",
-      "es": "Set criocrono",
       "it": "Panoplia Criocronica",
+      "es": "Set criocrono",
       "pt": "Conjunto Criocrono"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Intelligence",
-          "value": 50,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Initiative",
-          "value": 300,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "AP Parry",
           "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 8,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 8,
           "altStat": null
         }
       ],
       "3": [
-        {
-          "stat": "Intelligence",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Initiative",
-          "value": 300,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "AP Parry",
           "value": 15,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Initiative",
+          "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 8,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 8,
           "altStat": null
         }
       ]
@@ -976,8 +1253,8 @@
       "en": "Dark Court Set",
       "fr": "Panoplie de la Cour Sombre",
       "de": "Düsterhof-Set",
-      "es": "Set de cortesano tenebroso",
       "it": "Panoplia della Corte Oscura",
+      "es": "Set de cortesano tenebroso",
       "pt": "Conjunto da Corte Sombria"
     },
     "bonuses": {
@@ -989,34 +1266,40 @@
         },
         {
           "stat": "Strength",
-          "value": 30,
+          "value": 50,
           "altStat": null
         },
         {
           "stat": "AP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
           "value": 5,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "AP Reduction",
-          "value": 5,
+          "stat": "Initiative",
+          "value": 500,
           "altStat": null
         },
         {
           "stat": "Strength",
-          "value": 30,
+          "value": 50,
           "altStat": null
         },
         {
-          "stat": "Initiative",
-          "value": 500,
+          "stat": "AP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Critical",
+          "value": 5,
           "altStat": null
         }
       ]
@@ -1028,47 +1311,83 @@
       "en": "Lwo Set",
       "fr": "Panoplibou",
       "de": "Eulen-Set",
-      "es": "Buhoset",
       "it": "Gufinoplia",
+      "es": "Buhoset",
       "pt": "Corujunto"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Agility",
-          "value": 30,
+          "value": 50,
           "altStat": null
         },
         {
           "stat": "Pushback Damage",
-          "value": 15,
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": -10,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
-          "value": 5,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 8,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Lock",
+          "value": -10,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "MP Reduction",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "Pushback Damage",
-          "value": 15,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 30,
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 8,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -1080,8 +1399,8 @@
       "en": "Atcham Set",
       "fr": "Panoplie d'Atcham",
       "de": "Atcham-Set",
-      "es": "Set de Atcham",
       "it": "Panoplia di Atcham",
+      "es": "Set de Atcham",
       "pt": "Conjunto do Atcham"
     },
     "bonuses": {
@@ -1103,12 +1422,27 @@
         },
         {
           "stat": "AP Reduction",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "Critical Damage",
-          "value": 10,
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 7,
           "altStat": null
         }
       ],
@@ -1130,17 +1464,28 @@
         },
         {
           "stat": "AP Reduction",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Damage",
           "value": 10,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Critical Damage",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "% Fire Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 7,
           "altStat": null
         }
       ]
@@ -1152,20 +1497,25 @@
       "en": "Ilyzaelle Set",
       "fr": "Panoplie d'Ilyzaelle",
       "de": "Set von Ilyzaelle",
-      "es": "Set de Ilyzaelle",
       "it": "Panoplia di Ilyzaelle",
+      "es": "Set de Ilyzaelle",
       "pt": "Conjunto da Ilyzaelle"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Air Damage",
-          "value": 15,
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "Water Damage",
-          "value": 15,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 80,
           "altStat": null
         },
         {
@@ -1174,15 +1524,25 @@
           "altStat": null
         },
         {
-          "stat": "Heals",
-          "value": 60,
+          "stat": "MP Parry",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Air Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 80,
           "altStat": null
         },
         {
@@ -1190,19 +1550,10 @@
           "value": -10,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Heals",
-          "value": 60,
-          "altStat": null
-        },
-        {
-          "stat": "Water Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 15,
+          "stat": "MP Parry",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -1214,8 +1565,8 @@
       "en": "Soul-Blaze Set",
       "fr": "Panoplie Brûlâme",
       "de": "Set der Brennenden Seelen",
-      "es": "Set de quemaalmas",
       "it": "Panoplia Brucianima",
+      "es": "Set de quemaalmas",
       "pt": "Conjunto Almardente"
     },
     "bonuses": {
@@ -1234,12 +1585,28 @@
           "stat": "Range",
           "value": 1,
           "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Critical Resistance",
-          "value": 20,
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         },
         {
@@ -1248,13 +1615,23 @@
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Critical Resistance",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
           "altStat": null
         }
       ]
@@ -1266,15 +1643,15 @@
       "en": "Count Harebourg Set",
       "fr": "Panoplie du Comte Harebourg",
       "de": "Set von Graf Primzahl",
-      "es": "Set del conde Kontatrás",
       "it": "Panoplia del Conte Allarovescia",
+      "es": "Set del conde Kontatrás",
       "pt": "Conjunto do Conde Traspafrent"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Vitality",
-          "value": 100,
+          "value": 300,
           "altStat": null
         },
         {
@@ -1283,20 +1660,46 @@
           "altStat": null
         },
         {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
           "stat": "Lock",
-          "value": 10,
+          "value": 15,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
+          "stat": "Range",
           "value": 1,
           "altStat": null
         },
         {
+          "stat": "Critical Resistance",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
           "stat": "Lock",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
@@ -1306,7 +1709,42 @@
         },
         {
           "stat": "Vitality",
-          "value": 100,
+          "value": 300,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Neutral Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 15,
           "altStat": null
         }
       ]
@@ -1318,15 +1756,15 @@
       "en": "Treadfast Set",
       "fr": "Panoplie du Strigide",
       "de": "Stringid-Set",
-      "es": "Set de estrígido",
       "it": "Panoplia della Strigida",
+      "es": "Set de estrígido",
       "pt": "Conjunto do Strígido"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Vitality",
-          "value": 100,
+          "stat": "AP Parry",
+          "value": 10,
           "altStat": null
         },
         {
@@ -1336,16 +1774,22 @@
         },
         {
           "stat": "Critical Damage",
-          "value": 20,
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 15,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Critical",
+          "value": 5,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Critical Damage",
           "value": 20,
@@ -1357,8 +1801,13 @@
           "altStat": null
         },
         {
-          "stat": "Vitality",
-          "value": 100,
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 15,
           "altStat": null
         }
       ]
@@ -1370,8 +1819,8 @@
       "en": "Staruman Set",
       "fr": "Panoplie du Barbétoal",
       "de": "Bartagon-Set",
-      "es": "Set de barbestrella",
       "it": "Panoplia del Barbastella",
+      "es": "Set de barbestrella",
       "pt": "Conjunto do Barbastrela"
     },
     "bonuses": {
@@ -1388,19 +1837,19 @@
         },
         {
           "stat": "AP Reduction",
-          "value": 5,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Damage",
+          "value": 30,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "AP Reduction",
-          "value": 5,
+          "stat": "Agility",
+          "value": 40,
           "altStat": null
         },
         {
@@ -1409,8 +1858,14 @@
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 40,
+          "stat": "AP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Pushback Damage",
+          "value": 30,
           "altStat": null
         }
       ]
@@ -1422,47 +1877,73 @@
       "en": "Nidas Set",
       "fr": "Panoplie de Nidas",
       "de": "Nidas-Set",
-      "es": "Set de Nidas",
       "it": "Panoplia di Nida",
+      "es": "Set de Nidas",
       "pt": "Conjunto de Nidas"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Dodge",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Heals",
           "value": 10,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
+          "stat": "Heals",
           "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
+          "stat": "Range",
           "value": 1,
           "altStat": null
         },
         {
+          "stat": "MP Reduction",
+          "value": 15,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
           "stat": "Heals",
-          "value": 10,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 30,
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -1474,47 +1955,83 @@
       "en": "Hairsh Set",
       "fr": "Panoplie du Piloztère",
       "de": "Haarraff-Set",
-      "es": "Set de melenutrof",
       "it": "Panoplia del Pelaustero",
+      "es": "Set de melenutrof",
       "pt": "Conjunto do Pelutrof"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Strength",
-          "value": 40,
+          "stat": "Neutral Damage",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 40,
+          "stat": "Earth Damage",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "Critical Resistance",
-          "value": 20,
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
+          "value": 1,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 2, "altStat": null },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
           "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Resistance",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
-          "value": 40,
           "altStat": null
         }
       ]
@@ -1526,8 +2043,8 @@
       "en": "King Playa Set",
       "fr": "Panoplie du Roi Joueur",
       "de": "Spielerkönig-Set",
-      "es": "Set del rey jugador",
       "it": "Panoplia del Re Giocatore",
+      "es": "Set del rey jugador",
       "pt": "Conjunto do Rei Jogador"
     },
     "bonuses": {
@@ -1543,20 +2060,26 @@
           "altStat": null
         },
         {
-          "stat": "Critical Resistance",
-          "value": 20,
+          "stat": "MP Reduction",
+          "value": 10,
           "altStat": null
         },
         {
-          "stat": "MP Reduction",
-          "value": 5,
+          "stat": "Critical Resistance",
+          "value": 30,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Critical Resistance",
-          "value": 20,
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Intelligence",
+          "value": 40,
           "altStat": null
         },
         {
@@ -1565,18 +2088,8 @@
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "MP Reduction",
-          "value": 5,
+          "stat": "Critical Resistance",
+          "value": 30,
           "altStat": null
         }
       ]
@@ -1588,8 +2101,8 @@
       "en": "Jammy Jack Set",
       "fr": "Panoplie du Valet Veinard",
       "de": "Glücksbube-Set",
-      "es": "Set de la sota afortunada",
       "it": "Panoplia del Valletto Fortunato",
+      "es": "Set de la sota afortunada",
       "pt": "Conjunto do Valete Venturoso"
     },
     "bonuses": {
@@ -1601,24 +2114,30 @@
         },
         {
           "stat": "Air Damage",
-          "value": 15,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
           "stat": "Air Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "Agility",
           "value": 50,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "MP Parry",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -1630,8 +2149,8 @@
       "en": "Tritun Set",
       "fr": "Panoplie Trithon",
       "de": "Trithun-Set",
-      "es": "Set trithón",
       "it": "Panoplia Tritonna",
+      "es": "Set trithón",
       "pt": "Conjunto de Triatum"
     },
     "bonuses": {
@@ -1639,6 +2158,16 @@
         {
           "stat": "Power",
           "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 10,
           "altStat": null
         }
       ],
@@ -1648,9 +2177,15 @@
           "value": 100,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -1662,77 +2197,93 @@
       "en": "Unspeakable Set",
       "fr": "Panoplie de l'Indicible",
       "de": "Set des Unaussprechlichen",
-      "es": "Set de lo indecible",
       "it": "Panoplia dell'Indicibile",
+      "es": "Set de lo indecible",
       "pt": "Conjunto do indizível"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Strength",
-          "value": 50,
+          "stat": "Earth Damage",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 50,
+          "stat": "Fire Damage",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Critical",
-          "value": 5,
+          "stat": "Water Damage",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 20,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 50,
+          "stat": "Critical",
+          "value": 12,
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 50,
+          "stat": "Neutral Damage",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Earth Damage",
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Critical",
-          "value": 5,
+          "stat": "Fire Damage",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 50,
+          "stat": "Critical",
+          "value": 12,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Neutral Damage",
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Intelligence",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
-          "value": 50,
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         }
       ]
@@ -1744,47 +2295,93 @@
       "en": "Volcanic Set",
       "fr": "Panoplie Volcanique",
       "de": "Vulkanisches Set",
-      "es": "Set volcánico",
       "it": "Panoplia Vulcanica",
+      "es": "Set volcánico",
       "pt": "Conjunto Vulcânico"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Pushback Resistance",
+          "stat": "Heals",
           "value": 50,
           "altStat": null
         },
         {
           "stat": "Lock",
-          "value": 10,
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
           "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 80,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Pushback Resistance",
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
           "value": 50,
           "altStat": null
         },
         {
           "stat": "Lock",
-          "value": 10,
+          "value": 20,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
+          "value": 15,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "% Fire Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
           "value": 5,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Pushback Resistance",
+          "value": 80,
           "altStat": null
         }
       ]
@@ -1796,8 +2393,8 @@
       "en": "Grithril Set",
       "fr": "Grithriloplie",
       "de": "Grithril-Set",
-      "es": "Set de grithril",
       "it": "Grithriloplia",
+      "es": "Set de grithril",
       "pt": "Conjunto de Mithrinza"
     },
     "bonuses": {
@@ -1806,17 +2403,93 @@
           "stat": "Vitality",
           "value": 150,
           "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 10,
+          "altStat": null
         }
       ],
       "3": [
+        {
+          "stat": "Critical Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Vitality",
           "value": 150,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -1828,8 +2501,8 @@
       "en": "Rhineetle Set",
       "fr": "Panoplie Volkorne",
       "de": "Naskäfer-Set",
-      "es": "Set de vueloceronte",
       "it": "Panoplia Scaraceronte",
+      "es": "Set de vueloceronte",
       "pt": "Conjunto de Vulkórnio"
     },
     "bonuses": {
@@ -1845,27 +2518,7 @@
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Fire Damage",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Damage",
+          "stat": "Water Damage",
           "value": 10,
           "altStat": null
         },
@@ -1875,44 +2528,35 @@
           "altStat": null
         },
         {
-          "stat": "Water Damage",
+          "stat": "Earth Damage",
           "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 100,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "MP", "value": 1, "altStat": null },
         {
-          "stat": "Water Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Neutral Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Fire Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 150,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
+          "stat": "Strength",
           "value": 150,
           "altStat": null
         },
@@ -1922,49 +2566,45 @@
           "altStat": null
         },
         {
-          "stat": "Strength",
+          "stat": "Agility",
           "value": 150,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Chance",
+          "value": 150,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
           "altStat": null
         }
       ],
       "4": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Water Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Neutral Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Fire Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 150,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
+          "stat": "Strength",
           "value": 150,
           "altStat": null
         },
@@ -1974,13 +2614,38 @@
           "altStat": null
         },
         {
-          "stat": "Strength",
+          "stat": "Agility",
           "value": 150,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Chance",
+          "value": 150,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
           "altStat": null
         }
       ]
@@ -1992,20 +2657,25 @@
       "en": "Cycloid Set",
       "fr": "Panoplie du Cycloïde",
       "de": "Zykloid-Set",
-      "es": "Set de kukoloide",
       "it": "Panoplia del Cicloide",
+      "es": "Set de kukoloide",
       "pt": "Conjunto do Cicloide"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Strength",
-          "value": 40,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 40,
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
           "altStat": null
         },
         {
@@ -2014,29 +2684,44 @@
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 40,
+          "stat": "Critical",
+          "value": 12,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Critical",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Prospecting",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
+          "stat": "Strength",
           "value": 40,
           "altStat": null
         },
@@ -2046,8 +2731,49 @@
           "altStat": null
         },
         {
-          "stat": "Strength",
+          "stat": "Agility",
           "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 12,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 20,
           "altStat": null
         }
       ]
@@ -2059,66 +2785,61 @@
       "en": "Nocturnowl Set",
       "fr": "Panoplie du Nocturlabe",
       "de": "Nokturnal-Set",
-      "es": "Set de nocturlabiúho",
       "it": "Panoplia del Notturlabio",
+      "es": "Set de nocturlabiúho",
       "pt": "Conjunto do Nocturlábio"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Earth Damage",
-          "value": 25,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Water Damage",
-          "value": 25,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Critical",
-          "value": 7,
-          "altStat": null
-        },
-        {
-          "stat": "Range",
-          "value": 1,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Air Damage",
-          "value": 25,
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Resistance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Resistance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Damage",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Critical",
-          "value": 7,
-          "altStat": null
-        },
-        {
-          "stat": "Range",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
+          "stat": "Earth Damage",
           "value": 50,
           "altStat": null
         },
@@ -2128,8 +2849,54 @@
           "altStat": null
         },
         {
-          "stat": "Earth Damage",
+          "stat": "Air Damage",
           "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 50,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Fire Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Water Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Air Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -2141,77 +2908,108 @@
       "en": "Abyss Set",
       "fr": "Panoplie des Abysses",
       "de": "Abgründiges Set",
-      "es": "Set de los abismos",
       "it": "Panoplia degli Abissi",
+      "es": "Set de los abismos",
       "pt": "Conjunto dos Abismos"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Vitality",
-          "value": 100,
+          "value": 200,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 20,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 20,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 20,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Lock",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Pushback Resistance",
-          "value": 30,
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 15,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Vitality",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Intelligence",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Lock",
+          "stat": "% Earth Resistance",
           "value": 10,
           "altStat": null
         },
         {
+          "stat": "Vitality",
+          "value": 200,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Lock",
+          "value": 15,
+          "altStat": null
+        },
+        {
           "stat": "Pushback Resistance",
-          "value": 30,
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 15,
           "altStat": null
         }
       ]
@@ -2223,8 +3021,8 @@
       "en": "Levitrof Set",
       "fr": "Panoplie du Lévitrof",
       "de": "Levitrof-Set",
-      "es": "Set de levitrof",
       "it": "Panoplia del Levitatrof",
+      "es": "Set de levitrof",
       "pt": "Conjunto do Levitrof"
     },
     "bonuses": {
@@ -2240,27 +3038,78 @@
           "altStat": null
         },
         {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
           "stat": "Range",
           "value": 1,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Chance",
           "value": 30,
           "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 6,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 6,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 6,
+          "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Water Damage",
+          "value": 15,
           "altStat": null
         },
+        {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Range",
           "value": 1,
@@ -2268,7 +3117,7 @@
         },
         {
           "stat": "Dodge",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
@@ -2285,6 +3134,21 @@
           "stat": "Strength",
           "value": 30,
           "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 6,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 6,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 6,
+          "altStat": null
         }
       ]
     }
@@ -2295,8 +3159,8 @@
       "en": "Kamasterisk Set",
       "fr": "Panoplie du Kamasterisk",
       "de": "Kamasterisk-Set",
-      "es": "Set de kamasterix",
       "it": "Panoplia del Kamasterischio",
+      "es": "Set de kamasterix",
       "pt": "Conjunto do Kamasterisko"
     },
     "bonuses": {
@@ -2312,12 +3176,57 @@
           "altStat": null
         },
         {
-          "stat": "Critical",
-          "value": 6,
+          "stat": "Critical Resistance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 15,
           "altStat": null
         }
       ],
       "3": [
+        {
+          "stat": "Critical Resistance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
         {
           "stat": "Strength",
           "value": 40,
@@ -2329,13 +3238,24 @@
           "altStat": null
         },
         {
-          "stat": "Critical",
-          "value": 6,
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Neutral Damage",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 15,
           "altStat": null
         }
       ]
@@ -2347,8 +3267,8 @@
       "en": "Vortex Set",
       "fr": "Panoplie de Vortex",
       "de": "Vortex-Set",
-      "es": "Set de Vórtex",
       "it": "Panoplia di Vortice",
+      "es": "Set de Vórtex",
       "pt": "Conjunto de Vórtex"
     },
     "bonuses": {
@@ -2364,12 +3284,22 @@
           "altStat": null
         },
         {
+          "stat": "Heals",
+          "value": 30,
+          "altStat": null
+        },
+        {
           "stat": "AP Reduction",
-          "value": 5,
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
+        {
+          "stat": "Heals",
+          "value": 30,
+          "altStat": null
+        },
         {
           "stat": "Intelligence",
           "value": 40,
@@ -2382,14 +3312,10 @@
         },
         {
           "stat": "AP Reduction",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        }
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -2399,15 +3325,15 @@
       "en": "Deep Sea Set",
       "fr": "Panoplie des Fonds marins",
       "de": "Meeresgrund-Set",
-      "es": "Set de los fondos marinos",
       "it": "Panoplia Mare Profondo",
+      "es": "Set de los fondos marinos",
       "pt": "Conjunto do Fundo do Mar"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Chance",
-          "value": 30,
+          "value": 50,
           "altStat": null
         },
         {
@@ -2417,19 +3343,15 @@
         },
         {
           "stat": "MP Parry",
-          "value": 5,
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Chance",
-          "value": 30,
+          "value": 50,
           "altStat": null
         },
         {
@@ -2439,7 +3361,7 @@
         },
         {
           "stat": "MP Parry",
-          "value": 5,
+          "value": 10,
           "altStat": null
         }
       ]
@@ -2451,8 +3373,8 @@
       "en": "Voldelor Set",
       "fr": "Panoplie de Voldelor",
       "de": "Goldehort-Set",
-      "es": "Set de Dambeldoro",
       "it": "Panoplia di Voromort",
+      "es": "Set de Dambeldoro",
       "pt": "Conjunto do Vouromort"
     },
     "bonuses": {
@@ -2469,19 +3391,30 @@
         },
         {
           "stat": "Critical",
-          "value": 5,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         }
       ],
       "3": [
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Critical",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
         {
@@ -2493,6 +3426,21 @@
           "stat": "Agility",
           "value": 40,
           "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
         }
       ]
     }
@@ -2503,37 +3451,73 @@
       "en": "Kongoku Set",
       "fr": "Panoplie de Kongoku",
       "de": "Kongoku-Set",
-      "es": "Set de Kongoku",
       "it": "Panoplia di Kongoku",
+      "es": "Set de Kongoku",
       "pt": "Conjunto do Kongoku"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Vitality",
-          "value": 100,
+          "value": 200,
           "altStat": null
         },
         {
           "stat": "Critical Resistance",
           "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 500,
           "altStat": null
         }
       ],
       "3": [
         {
+          "stat": "MP Reduction",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 30,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Critical Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
           "stat": "Vitality",
+          "value": 200,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
           "value": 100,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Resistance",
-          "value": 30,
+          "stat": "Initiative",
+          "value": 500,
           "altStat": null
         }
       ]
@@ -2545,8 +3529,8 @@
       "en": "Luminescent Set",
       "fr": "Panoplie Luminescente",
       "de": "Lumineszierendes Set",
-      "es": "Set luminiscente",
       "it": "Panoplia Luminescente",
+      "es": "Set luminiscente",
       "pt": "Conjunto luminescente"
     },
     "bonuses": {
@@ -2562,30 +3546,36 @@
           "altStat": null
         },
         {
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
           "stat": "Pushback Damage",
-          "value": 15,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Lock",
-          "value": 5,
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "MP Reduction",
+          "value": 10,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Pushback Damage",
-          "value": 15,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Lock",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
         {
@@ -2605,10 +3595,10 @@
     "id": "418",
     "name": {
       "en": "Rygurgal Set",
-      "fr": "Panoplie de R’lyugluglu",
+      "fr": "Panoplie de R'lyugluglu",
       "de": "R'lyuhgurgl-Set",
-      "es": "Set de Rylugluglú",
       "it": "Panoplia di R'lyugluglu",
+      "es": "Set de Rylugluglú",
       "pt": "Conjunto de R'lyugluglu"
     },
     "bonuses": {
@@ -2624,30 +3614,20 @@
           "altStat": null
         },
         {
-          "stat": "Heals",
-          "value": 10,
+          "stat": "Critical Resistance",
+          "value": 25,
           "altStat": null
         },
         {
-          "stat": "Critical Resistance",
-          "value": 10,
+          "stat": "Heals",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Heals",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Resistance",
-          "value": 10,
+          "stat": "Intelligence",
+          "value": 40,
           "altStat": null
         },
         {
@@ -2656,10 +3636,16 @@
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 40,
+          "stat": "Critical Resistance",
+          "value": 25,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Heals",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -2669,8 +3655,8 @@
       "en": "Setstik",
       "fr": "Panoplistik",
       "de": "Mumford-Set",
-      "es": "Set momístico",
       "it": "Panoplia del Mummistico",
+      "es": "Set momístico",
       "pt": "Conjunto de Mumístika"
     },
     "bonuses": {
@@ -2682,34 +3668,50 @@
         },
         {
           "stat": "Pushback Damage",
-          "value": 20,
+          "value": 25,
           "altStat": null
         },
         {
           "stat": "Heals",
-          "value": 10,
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 40,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Heals",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Damage",
+          "value": 25,
+          "altStat": null
+        },
         {
           "stat": "Critical Resistance",
           "value": 30,
           "altStat": null
         },
         {
-          "stat": "Pushback Damage",
-          "value": 20,
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Heals",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Intelligence",
+          "value": 40,
           "altStat": null
         }
       ]
@@ -2803,8 +3805,8 @@
       "en": "Ghoul Set",
       "fr": "Panoplie de la Goule",
       "de": "Ghul-Set",
-      "es": "Set de ghul",
       "it": "Panoplia del Ghoul",
+      "es": "Set de ghul",
       "pt": "Conjunto do Carniçal"
     },
     "bonuses": {
@@ -2816,7 +3818,22 @@
         },
         {
           "stat": "AP Parry",
-          "value": 15,
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
           "altStat": null
         }
       ],
@@ -2826,14 +3843,25 @@
           "value": 40,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "AP Parry",
-          "value": 15,
+          "value": 25,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
           "altStat": null
         }
       ]
@@ -2845,27 +3873,53 @@
       "en": "Unsound Mind Set",
       "fr": "Panoplie de l'Esprit Malsain",
       "de": "Set des Kranken Geistes",
-      "es": "Set del Espíritu Insano",
       "it": "Panoplia dello Spirito Malsano",
+      "es": "Set del Espíritu Insano",
       "pt": "Conjunto do Espírito Doentio"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Range",
-          "value": 2,
+          "stat": "Heals",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 8,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Range",
-          "value": 2,
+          "stat": "Heals",
+          "value": 50,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "MP Parry",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 8,
           "altStat": null
         }
       ]
@@ -2877,8 +3931,8 @@
       "en": "Sharp Eye Set",
       "fr": "Panoplie de l'Œil Attentif",
       "de": "Set des Allsehenden Auges",
-      "es": "Set del Ojo Atento",
       "it": "Panoplia dell'Occhio Attento",
+      "es": "Set del Ojo Atento",
       "pt": "Conjunto do Olho Observador"
     },
     "bonuses": {
@@ -2887,17 +3941,33 @@
           "stat": "AP Parry",
           "value": 20,
           "altStat": null
-        }
-      ],
-      "3": [
+        },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Dodge",
+          "value": 10,
           "altStat": null
         },
         {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        }
+      ],
+      "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
           "stat": "AP Parry",
           "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         }
       ]
@@ -2909,15 +3979,15 @@
       "en": "Burning Set",
       "fr": "Panoplie Ardente",
       "de": "Feuriges Set",
-      "es": "Set ardiente",
       "it": "Panoplia Ardente",
+      "es": "Set ardiente",
       "pt": "Conjunto Ardente"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Lock",
-          "value": 10,
+          "value": 20,
           "altStat": null
         },
         {
@@ -2926,15 +3996,35 @@
           "altStat": null
         },
         {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
           "stat": "Heals",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
           "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
           "stat": "Lock",
-          "value": 10,
+          "value": 20,
           "altStat": null
         },
         {
@@ -2944,12 +4034,18 @@
         },
         {
           "stat": "Heals",
+          "value": 30,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "% Fire Resistance",
           "value": 10,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "% Water Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -2993,8 +4089,8 @@
       "en": "Freezammer Set",
       "fr": "Panoplie Martegel",
       "de": "Eishämmer-Set",
+      "it": "Panoplia Martelgeloù",
       "es": "Set de Martillelo",
-      "it": "Panoplia Martelgelo",
       "pt": "Conjunto Martegelo"
     },
     "bonuses": {
@@ -3003,17 +4099,53 @@
           "stat": "Initiative",
           "value": 1500,
           "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
         }
       ],
       "3": [
+        {
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Initiative",
           "value": 1500,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 40,
           "altStat": null
         }
       ]
@@ -3025,8 +4157,8 @@
       "en": "Misery Set",
       "fr": "Panoplie de Misère",
       "de": "Elend-Set",
-      "es": "Set de Miseria",
       "it": "Panoplia di Miseria",
+      "es": "Set de Miseria",
       "pt": "Conjunto de Miséria"
     },
     "bonuses": {
@@ -3042,35 +4174,25 @@
           "altStat": null
         },
         {
-          "stat": "AP Parry",
+          "stat": "Critical Damage",
           "value": 15,
           "altStat": null
         },
         {
           "stat": "MP Parry",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Damage",
-          "value": 10,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "Critical Damage",
           "value": 20,
           "altStat": null
         },
         {
           "stat": "AP Parry",
-          "value": 40,
+          "value": 20,
           "altStat": null
-        },
+        }
+      ],
+      "3": [
         {
-          "stat": "MP Parry",
-          "value": 40,
+          "stat": "Chance",
+          "value": 20,
           "altStat": null
         },
         {
@@ -3079,10 +4201,21 @@
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 20,
+          "stat": "MP Parry",
+          "value": 40,
           "altStat": null
-        }
+        },
+        {
+          "stat": "AP Parry",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 15,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -3092,8 +4225,8 @@
       "en": "Malitiamen Set",
       "fr": "Panoplie des Malveilleurs",
       "de": "Garstibö-Set",
-      "es": "Set de maligilante",
       "it": "Panoplia dei Malevoli",
+      "es": "Set de maligilante",
       "pt": "Conjunto dos Malevigiantes"
     },
     "bonuses": {
@@ -3110,49 +4243,65 @@
         },
         {
           "stat": "Pushback Damage",
-          "value": 10,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Lock",
-          "value": 5,
+          "stat": "Critical",
+          "value": 12,
           "altStat": null
         },
         {
           "stat": "Chance",
           "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 7,
           "altStat": null
         }
       ],
       "3": [
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Pushback Damage",
-          "value": 10,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Lock",
-          "value": 5,
+          "stat": "Critical",
+          "value": 12,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 30,
+          "value": 60,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 30,
+          "value": 60,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 30,
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 7,
           "altStat": null
         }
       ]
@@ -3164,8 +4313,8 @@
       "en": "Fugitive Set",
       "fr": "Panoplie des égarés",
       "de": "Set der Verlorenen",
-      "es": "Set de los idos",
       "it": "Panoplia dei Perduti",
+      "es": "Set de los idos",
       "pt": "Conjunto dos Perdidos"
     },
     "bonuses": {
@@ -3181,12 +4330,27 @@
           "altStat": null
         },
         {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
           "stat": "MP Parry",
-          "value": 5,
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
         {
           "stat": "Strength",
           "value": 40,
@@ -3199,12 +4363,13 @@
         },
         {
           "stat": "MP Parry",
-          "value": 5,
+          "value": 15,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "% Earth Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -3216,8 +4381,8 @@
       "en": "Mesm Set",
       "fr": "Panoplie Pnose",
       "de": "Hype Nose - Set",
-      "es": "Hipnoset",
       "it": "Panoplipnosi",
+      "es": "Hipnoset",
       "pt": "Hipnojunto"
     },
     "bonuses": {
@@ -3234,29 +4399,35 @@
         },
         {
           "stat": "Heals",
-          "value": 10,
+          "value": 20,
           "altStat": null
         },
         {
           "stat": "Pushback Damage",
-          "value": 15,
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 7,
           "altStat": null
         }
       ],
       "3": [
-        {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Heals",
-          "value": 10,
+          "value": 20,
           "altStat": null
         },
         {
           "stat": "Pushback Damage",
-          "value": 15,
+          "value": 25,
           "altStat": null
         },
         {
@@ -3268,6 +4439,16 @@
           "stat": "Intelligence",
           "value": 40,
           "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 7,
+          "altStat": null
         }
       ]
     }
@@ -3278,8 +4459,8 @@
       "en": "Queen of Fate Set",
       "fr": "Panoplie de la Dame du Hasard",
       "de": "Glücksdame-Set",
-      "es": "Set de la reina del azar",
       "it": "Panoplia della Dama dell'Azzardo",
+      "es": "Set de la reina del azar",
       "pt": "Conjunto da Dama do Azar"
     },
     "bonuses": {
@@ -3295,22 +4476,33 @@
           "altStat": null
         },
         {
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
           "stat": "Critical Damage",
           "value": 15,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 5,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "MP Reduction",
+          "value": 10,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Critical Damage",
           "value": 15,
@@ -3318,7 +4510,7 @@
         },
         {
           "stat": "Dodge",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
         {
@@ -3329,6 +4521,11 @@
         {
           "stat": "Intelligence",
           "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -3340,47 +4537,83 @@
       "en": "Meno Set",
       "fr": "Panoplie de Meno",
       "de": "Meno-Set",
-      "es": "Set de Meno",
       "it": "Panoplia di Meno",
+      "es": "Set de Meno",
       "pt": "Conjunto de Meno"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Intelligence",
-          "value": 40,
+          "stat": "Fire Damage",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 40,
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
-          "value": 5,
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
+          "stat": "Critical",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 30,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "MP Reduction",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
           "value": 1,
           "altStat": null
         },
         {
-          "stat": "MP Reduction",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Intelligence",
-          "value": 40,
+          "stat": "% Fire Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -3392,37 +4625,53 @@
       "en": "Valiant Heart Set",
       "fr": "Panoplie du Cœur Vaillant",
       "de": "Set des Tapferen Herzens",
-      "es": "Set del Corazón Valiente",
       "it": "Panoplia del Cuore Valoroso",
+      "es": "Set del Corazón Valiente",
       "pt": "Conjunto do Coração Valente"
     },
     "bonuses": {
       "2": [
         {
           "stat": "AP Reduction",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Critical",
-          "value": 4,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Damage",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 150,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP Reduction",
-          "value": 10,
+          "stat": "Pushback Damage",
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Critical",
-          "value": 4,
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "AP Reduction",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Vitality",
+          "value": 150,
           "altStat": null
         }
       ]
@@ -3434,8 +4683,8 @@
       "en": "Salvatory Spirit Set",
       "fr": "Panoplie de l'Esprit Salvateur",
       "de": "Set des Rettenden Geistes",
-      "es": "Set del Espíritu de la Salvación",
       "it": "Panoplia dello Spirito Redentore",
+      "es": "Set del Espíritu de la Salvación",
       "pt": "Conjunto do Espírito Salvador"
     },
     "bonuses": {
@@ -3443,6 +4692,21 @@
         {
           "stat": "Dodge",
           "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 35,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 80,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 150,
           "altStat": null
         }
       ],
@@ -3453,8 +4717,19 @@
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Critical Resistance",
+          "value": 35,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Heals",
+          "value": 80,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 150,
           "altStat": null
         }
       ]
@@ -3466,20 +4741,30 @@
       "en": "Paztek Set",
       "fr": "Panoplie Paztek",
       "de": "Paztek-Set",
-      "es": "Set pazteka",
       "it": "Panoplia Pazteka",
+      "es": "Set pazteka",
       "pt": "Conjunto Melazteca"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Pushback Damage",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Vitality",
-          "value": 50,
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 10,
           "altStat": null
         }
       ],
@@ -3490,15 +4775,21 @@
           "altStat": null
         },
         {
-          "stat": "Vitality",
-          "value": 100,
+          "stat": "Fire Damage",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Water Damage",
+          "value": 15,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Lock",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -3560,8 +4851,8 @@
       "en": "Corruption Set",
       "fr": "Panoplie de Corruption",
       "de": "Verderbnis-Set",
-      "es": "Set de Corrupción",
       "it": "Panoplia di Corruzione",
+      "es": "Set de Corrupción",
       "pt": "Conjunto de Corrupção"
     },
     "bonuses": {
@@ -3573,7 +4864,17 @@
         },
         {
           "stat": "Critical Damage",
-          "value": 20,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": -5,
           "altStat": null
         }
       ],
@@ -3584,15 +4885,21 @@
           "altStat": null
         },
         {
-          "stat": "Critical Damage",
-          "value": 20,
-          "altStat": null
-        },
-        {
           "stat": "Critical",
           "value": 7,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": -5,
+          "altStat": null
+        },
+        { "stat": "MP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -3600,135 +4907,218 @@
     "id": "189",
     "name": {
       "en": "Celestial Bearbarian Set",
-      "fr": "Panoplie Glourséleste",
-      "de": "Himmlisches Barbärenset",
-      "es": "Set de Golosotrón Real",
+      "fr": "Panoplie du Glourséleste",
+      "de": "Set des Himmlischen Barbären",
       "it": "Panoplia di Mielorceleste",
-      "pt": "Conjunto Glurseleste"
+      "es": "Set del Golosotrón Real",
+      "pt": "Conjunto do Glurseleste"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Prospecting",
+          "stat": "Intelligence",
           "value": 20,
           "altStat": null
-        }
-      ],
-      "3": [
+        },
         {
-          "stat": "Prospecting",
-          "value": 40,
+          "stat": "Chance",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Neutral Resistance",
-          "value": 4,
+          "stat": "Agility",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Water Resistance",
-          "value": 4,
-          "altStat": null
-        },
-        {
-          "stat": "Air Resistance",
-          "value": 4,
-          "altStat": null
-        },
-        {
-          "stat": "Fire Resistance",
-          "value": 4,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Resistance",
-          "value": 4,
-          "altStat": null
-        },
-        {
-          "stat": "Lock",
-          "value": -20,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": "Water Resistance",
-          "value": 8,
-          "altStat": null
-        },
-        {
-          "stat": "Air Resistance",
-          "value": 8,
-          "altStat": null
-        },
-        {
-          "stat": "Fire Resistance",
-          "value": 8,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Resistance",
-          "value": 8,
-          "altStat": null
-        },
-        {
-          "stat": "Neutral Resistance",
-          "value": 8,
+          "stat": "Dodge",
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Prospecting",
-          "value": 60,
+          "value": 20,
           "altStat": null
         },
         {
           "stat": "Lock",
           "value": -40,
           "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 5,
+          "altStat": null
         }
       ],
-      "5": [
+      "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Intelligence",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Water Resistance",
-          "value": 12,
+          "stat": "Chance",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Air Resistance",
-          "value": 12,
+          "stat": "Agility",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Fire Resistance",
-          "value": 12,
+          "stat": "Dodge",
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "Earth Resistance",
-          "value": 12,
-          "altStat": null
-        },
-        {
-          "stat": "Neutral Resistance",
-          "value": 12,
+          "stat": "MP Reduction",
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Prospecting",
-          "value": 80,
+          "value": 20,
           "altStat": null
         },
         {
           "stat": "Lock",
-          "value": -60,
+          "value": -40,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
+      ],
+      "4": [
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Water Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Air Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": -40,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
+      ],
+      "5": [
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Water Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Air Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": -40,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -3738,8 +5128,8 @@
       "en": "Father Whupper Set",
       "fr": "Panoplie du Père Fwetar",
       "de": "Rubrächer, der Knechter - Set",
-      "es": "Set de Papa No-es",
       "it": "Panoplia di Papy Pawty",
+      "es": "Set de Papa No-es",
       "pt": "Conjunto do Papai Cruel"
     },
     "bonuses": {
@@ -3751,24 +5141,30 @@
         },
         {
           "stat": "Critical Resistance",
-          "value": 20,
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 7,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Power",
-          "value": 30,
+          "stat": "AP Parry",
+          "value": 7,
           "altStat": null
         },
         {
           "stat": "Critical Resistance",
-          "value": 20,
+          "value": 50,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Power",
+          "value": 30,
           "altStat": null
         }
       ]
@@ -3780,44 +5176,45 @@
       "en": "Bearbaric Set",
       "fr": "Panoplie Gloursonne",
       "de": "Barbärenstarkes Set",
-      "es": "Set golosón",
       "it": "Panoplia Mielorsa",
+      "es": "Set golosón",
       "pt": "Conjunto Glursão"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Neutral Damage",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Earth Damage",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Air Damage",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Water Damage",
-          "value": 10,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Fire Damage",
-          "value": 10,
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
+          "value": 1,
           "altStat": null
         }
       ],
       "3": [
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Air Damage",
           "value": 20,
@@ -3841,6 +5238,31 @@
         {
           "stat": "Neutral Damage",
           "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 50,
           "altStat": null
         }
       ]
@@ -3852,57 +5274,103 @@
       "en": "Oshimo Set",
       "fr": "Panoplie d'Oshimo",
       "de": "Oshimo-Set",
-      "es": "Set de Yokashi",
       "it": "Panoplia di Oshimo",
+      "es": "Set de Yokashi",
       "pt": "Conjunto de Oshimo"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Strength",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Lock",
-          "value": 5,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Initiative",
-          "value": 200,
+          "value": 500,
           "altStat": null
-        }
-      ],
-      "3": [
+        },
         {
           "stat": "Lock",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
           "value": 10,
           "altStat": null
         },
         {
+          "stat": "Vitality",
+          "value": 200,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        }
+      ],
+      "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
           "stat": "Initiative",
-          "value": 400,
+          "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 40,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Strength",
-          "value": 40,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Vitality",
+          "value": 200,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
           "altStat": null
         }
       ]
@@ -3914,49 +5382,75 @@
       "en": "Lethaline Set",
       "fr": "Panoplie de Léthaline",
       "de": "Lethalina-Set",
-      "es": "Set de Letalina",
       "it": "Panoplia di Lethalin",
+      "es": "Set de Letalina",
       "pt": "Conjunto de Letalina"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Power",
-          "value": 60,
+          "stat": "MP Reduction",
+          "value": 12,
+          "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 12,
           "altStat": null
         },
         {
           "stat": "Wisdom",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Prospecting",
-          "value": 20,
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "MP Reduction",
+          "value": 12,
           "altStat": null
         },
         {
-          "stat": "Prospecting",
-          "value": 40,
+          "stat": "AP Reduction",
+          "value": 12,
           "altStat": null
         },
         {
           "stat": "Wisdom",
-          "value": 40,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Power",
-          "value": 100,
+          "stat": "Prospecting",
+          "value": 30,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Heals",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -3966,8 +5460,8 @@
       "en": "Vicious Set",
       "fr": "Panoplie Vicieuse",
       "de": "Heimtückisches Set",
-      "es": "Set traicionero",
       "it": "Panoplia Viziosa",
+      "es": "Set traicionero",
       "pt": "Conjunto Vicioso"
     },
     "bonuses": {
@@ -3984,29 +5478,29 @@
         },
         {
           "stat": "MP Reduction",
-          "value": 8,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 16,
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "MP Reduction",
-          "value": 8,
-          "altStat": null
-        },
-        {
-          "stat": "Dodge",
-          "value": 16,
+          "stat": "Agility",
+          "value": 40,
           "altStat": null
         },
         {
@@ -4015,10 +5509,36 @@
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 40,
+          "stat": "MP Reduction",
+          "value": 15,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Dodge",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 5,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -4028,15 +5548,45 @@
       "en": "Unstable Set",
       "fr": "Panoplie Instable",
       "de": "Labiles Set",
-      "es": "Set inestable",
       "it": "Panoplia Instabile",
+      "es": "Set inestable",
       "pt": "Conjunto Instável"
     },
     "bonuses": {
       "2": [
         {
+          "stat": "Vitality",
+          "value": 200,
+          "altStat": null
+        },
+        {
           "stat": "Initiative",
           "value": 2000,
+          "altStat": null
+        },
+        {
+          "stat": "Wisdom",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 10,
           "altStat": null
         },
         {
@@ -4047,25 +5597,47 @@
       ],
       "3": [
         {
+          "stat": "Vitality",
+          "value": 200,
+          "altStat": null
+        },
+        {
           "stat": "Initiative",
           "value": 2000,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Wisdom",
+          "value": 50,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Lock",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "Prospecting",
           "value": 40,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        { "stat": "MP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -4075,8 +5647,8 @@
       "en": "Cartographer Set",
       "fr": "Panoplie du Cartographe",
       "de": "Kartographen-Set",
-      "es": "Set del cartógrafo",
       "it": "Panoplia del Cartografo",
+      "es": "Set del cartógrafo",
       "pt": "Conjunto do Cartógrafo"
     },
     "bonuses": {
@@ -4092,17 +5664,78 @@
           "altStat": null
         },
         {
+          "stat": "Pushback Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
           "stat": "Critical Resistance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 150,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
           "value": 20,
           "altStat": null
         },
         {
-          "stat": "Pushback Resistance",
-          "value": 30,
+          "stat": "% Water Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Air Resistance",
+          "value": 15,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Pushback Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
         {
           "stat": "Intelligence",
           "value": 30,
@@ -4114,18 +5747,43 @@
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Air Resistance",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "Critical Resistance",
+          "stat": "Fire Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
           "value": 20,
           "altStat": null
         },
         {
-          "stat": "Pushback Resistance",
-          "value": 30,
+          "stat": "Vitality",
+          "value": 150,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 50,
           "altStat": null
         }
       ]
@@ -4137,26 +5795,112 @@
       "en": "Sucker Set",
       "fr": "Panoplie Ventouse",
       "de": "Saugnapf-Set",
-      "es": "Set ventosa",
       "it": "Panoplia Ventosa",
+      "es": "Set ventosa",
       "pt": "Conjunto Ventosa"
     },
     "bonuses": {
       "2": [
         {
+          "stat": "Power",
+          "value": 40,
+          "altStat": null
+        },
+        {
           "stat": "Wisdom",
-          "value": 20,
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 50,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Air Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Wisdom",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 50,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Water Resistance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Resistance",
           "value": 20,
           "altStat": null
         }
@@ -4169,37 +5913,53 @@
       "en": "Nileza Set",
       "fr": "Panoplie de Nileza",
       "de": "Nileza-Set",
-      "es": "Set de Nileza",
       "it": "Panoplia di Nileza",
+      "es": "Set de Nileza",
       "pt": "Conjunto de Nileza"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Intelligence",
-          "value": 50,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Initiative",
           "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Intelligence",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
+          "stat": "Range",
           "value": 1,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Initiative",
           "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -4211,32 +5971,25 @@
       "en": "Brouce Boulgoure Set",
       "fr": "Panoplie de Brouce Boulgoure",
       "de": "Bruce Bulgour - Set",
-      "es": "Set de Brus Bulguro",
       "it": "Panoplia di Bruce Bulgur",
+      "es": "Set de Brus Bulguro",
       "pt": "Conjunto do Bruce Bulgur"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Critical",
-          "value": 2,
-          "altStat": null
-        },
-        {
-          "stat": "MP Parry",
-          "value": 5,
-          "altStat": null
-        },
-        {
           "stat": "Strength",
-          "value": 20,
+          "value": 40,
           "altStat": null
-        }
-      ],
-      "3": [
+        },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Critical",
+          "value": 3,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 5,
           "altStat": null
         },
         {
@@ -4245,15 +5998,38 @@
           "altStat": null
         },
         {
-          "stat": "Critical",
-          "value": 4,
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
-        },
+        }
+      ],
+      "3": [
         {
           "stat": "Strength",
           "value": 40,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Critical",
+          "value": 3,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -4263,42 +6039,20 @@
       "en": "Nomarow Set",
       "fr": "Panoplie de Padgref",
       "de": "Set des Knöchernen Marks",
-      "es": "Set de Noai Aludem",
       "it": "Panoplia di Padgref",
+      "es": "Set de Noai Aludem",
       "pt": "Conjunto de Nondome"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Intelligence",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Damage",
-          "value": 6,
-          "altStat": null
-        },
-        {
-          "stat": "Critical",
-          "value": 4,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Damage",
-          "value": 12,
+          "value": 30,
           "altStat": null
         },
         {
@@ -4307,15 +6061,53 @@
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 40,
+          "stat": "Critical Damage",
+          "value": 10,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 40,
+          "stat": "Lock",
+          "value": -10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": -10,
           "altStat": null
         }
+      ],
+      "3": [
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 8,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": -10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": -10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -4325,47 +6117,53 @@
       "en": "Sylargh Set",
       "fr": "Panoplie de Sylargh",
       "de": "Sylargh-Set",
-      "es": "Set de Sylargh",
       "it": "Panoplia di Sylargh",
+      "es": "Set de Sylargh",
       "pt": "Conjunto do Sylargh"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Strength",
-          "value": 50,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Pushback Damage",
-          "value": 30,
+          "stat": "Critical",
+          "value": 8,
           "altStat": null
         },
         {
-          "stat": "MP Parry",
+          "stat": "Lock",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
           "value": 10,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Strength",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Pushback Damage",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "MP Parry",
+          "stat": "Lock",
           "value": 10,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Critical",
+          "value": 8,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -4377,15 +6175,30 @@
       "en": "Kan-O-Mat Set",
       "fr": "Panoplie du Kanimate",
       "de": "Kanimat-Set",
-      "es": "Set de kanitómata",
       "it": "Panoplia del Kanibot",
+      "es": "Set de kanitómata",
       "pt": "Conjunto do Kanibot"
     },
     "bonuses": {
       "2": [
         {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
           "stat": "Chance",
-          "value": 80,
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 20,
           "altStat": null
         },
         {
@@ -4394,20 +6207,35 @@
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Air Damage",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Intelligence",
+          "value": 60,
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Chance",
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 20,
           "altStat": null
         },
         {
@@ -4416,10 +6244,16 @@
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 80,
+          "stat": "Air Damage",
+          "value": 20,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -4429,20 +6263,25 @@
       "en": "Barbakle Set",
       "fr": "Pikoplie",
       "de": "Pickollo-Set",
-      "es": "Pikoset",
       "it": "Agokunoplia",
+      "es": "Pikoset",
       "pt": "Pikonjunto"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Strength",
-          "value": 30,
+          "stat": "Neutral Damage",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 30,
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
           "altStat": null
         },
         {
@@ -4452,36 +6291,47 @@
         },
         {
           "stat": "MP Reduction",
-          "value": 5,
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": -5,
           "altStat": null
         }
       ],
       "3": [
         {
+          "stat": "Neutral Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
           "stat": "Range",
           "value": 1,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 30,
-          "altStat": null
-        },
-        {
           "stat": "MP Reduction",
-          "value": 5,
+          "value": 7,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Dodge",
+          "value": -5,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -4491,8 +6341,8 @@
       "en": "Quartzotic Set",
       "fr": "Panoplie Quartzésienne",
       "de": "Quarzesianisches Set",
-      "es": "Set Cuarzosiano",
       "it": "Panoplia Quarzesiana",
+      "es": "Set Cuarzosiano",
       "pt": "Conjunto Quartzesiano"
     },
     "bonuses": {
@@ -4508,20 +6358,26 @@
           "altStat": null
         },
         {
+          "stat": "MP Reduction",
+          "value": 5,
+          "altStat": null
+        },
+        {
           "stat": "Heals",
-          "value": 25,
+          "value": 40,
+          "altStat": null
+        }
+      ],
+      "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Heals",
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
           "value": 5,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "Agility",
-          "value": 40,
           "altStat": null
         },
         {
@@ -4530,18 +6386,8 @@
           "altStat": null
         },
         {
-          "stat": "MP Reduction",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Heals",
-          "value": 25,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Agility",
+          "value": 40,
           "altStat": null
         }
       ]
@@ -4553,30 +6399,30 @@
       "en": "Aermyne Set",
       "fr": "Panoplie d'Aermyne",
       "de": "Aermyne-Set",
-      "es": "Set de Aermyn",
       "it": "Panoplia di Aermyne",
+      "es": "Set de Aermyn",
       "pt": "Conjunto de Armyna"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Vitality",
-          "value": 100,
+          "value": 200,
           "altStat": null
         },
         {
           "stat": "Critical Resistance",
-          "value": 10,
+          "value": 60,
           "altStat": null
         },
         {
           "stat": "Pushback Resistance",
-          "value": 20,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Lock",
-          "value": 15,
+          "value": 30,
           "altStat": null
         }
       ],
@@ -4588,7 +6434,7 @@
         },
         {
           "stat": "Critical Resistance",
-          "value": 20,
+          "value": 60,
           "altStat": null
         },
         {
@@ -4597,15 +6443,11 @@
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
           "stat": "Lock",
           "value": 30,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -4615,57 +6457,93 @@
       "en": "Missiz Freezz Set",
       "fr": "Panoplie de Missiz Frizz",
       "de": "Set von Missiz Frizz",
-      "es": "Set de Mizz Frizz",
       "it": "Panoplia di Missiz Frizz",
+      "es": "Set de Mizz Frizz",
       "pt": "Conjunto da Missiz Frizz"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Vitality",
-          "value": 120,
+          "value": 150,
           "altStat": null
         },
         {
           "stat": "Strength",
-          "value": 60,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 30,
+          "stat": "Water Damage",
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 30,
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 7,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Vitality",
-          "value": 120,
+          "stat": "Water Damage",
+          "value": 10,
           "altStat": null
         },
         {
-          "stat": "Strength",
+          "stat": "Fire Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
           "value": 60,
           "altStat": null
         },
         {
           "stat": "Intelligence",
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
           "value": 30,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 30,
+          "stat": "Vitality",
+          "value": 150,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "% Earth Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 7,
           "altStat": null
         }
       ]
@@ -4677,57 +6555,83 @@
       "en": "Antyklime Ax Set",
       "fr": "Panoplie de Théodoran Ax",
       "de": "Theodoran X - Set",
-      "es": "Set de Ontoral Zo",
       "it": "Panoplia di Teodor Ant Ax",
+      "es": "Set de Ontoral Zo",
       "pt": "Conjunto de Theodorant Ax"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Intelligence",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 20,
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": -20,
           "altStat": null
         },
         {
           "stat": "Heals",
-          "value": 5,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Vitality",
-          "value": 100,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "AP",
-          "value": 1,
+          "value": 150,
           "altStat": null
         },
         {
-          "stat": "Heals",
+          "stat": "Fire Damage",
           "value": 10,
           "altStat": null
         },
         {
-          "stat": "Vitality",
-          "value": 200,
+          "stat": "Water Damage",
+          "value": 10,
+          "altStat": null
+        }
+      ],
+      "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Critical",
+          "value": -20,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 40,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 40,
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 150,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -4739,57 +6643,53 @@
       "en": "Hel Munster Set",
       "fr": "Panoplie d'Hel Munster",
       "de": "Hel Münster - Set",
-      "es": "Set de Hel Munster",
       "it": "Panoplia di Hel Munster",
+      "es": "Set de Hel Munster",
       "pt": "Conjunto de Hel Munster"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Chance",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Resistance",
-          "value": 5,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Range",
           "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 50,
           "altStat": null
         }
       ],
       "3": [
-        {
-          "stat": "Chance",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Resistance",
-          "value": 10,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Range",
           "value": 1,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Critical Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
           "altStat": null
         }
       ]
@@ -4801,15 +6701,15 @@
       "en": "Klime Set",
       "fr": "Panoplie de Klime",
       "de": "Set von R.Klimm",
-      "es": "Set de Klim",
       "it": "Panoplia di Klim",
+      "es": "Set de Klim",
       "pt": "Conjunto do Klim"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Agility",
-          "value": 50,
+          "value": 40,
           "altStat": null
         },
         {
@@ -4818,15 +6718,30 @@
           "altStat": null
         },
         {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
           "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
           "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
           "stat": "Agility",
-          "value": 50,
+          "value": 40,
           "altStat": null
         },
         {
@@ -4839,9 +6754,10 @@
           "value": 10,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "% Earth Resistance",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -4853,8 +6769,8 @@
       "en": "Shadow Set",
       "fr": "Panoplie d'Ombre",
       "de": "Schattenset",
-      "es": "Set de Sombra",
       "it": "Panoplia di Ombra",
+      "es": "Set de Sombra",
       "pt": "Conjunto do Sombra"
     },
     "bonuses": {
@@ -4870,17 +6786,28 @@
           "altStat": null
         },
         {
-          "stat": "MP Parry",
+          "stat": "Lock",
           "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 100,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Lock",
+          "value": 5,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Intelligence",
           "value": 30,
@@ -4893,7 +6820,12 @@
         },
         {
           "stat": "MP Parry",
-          "value": 5,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 100,
           "altStat": null
         }
       ]
@@ -4905,32 +6837,15 @@
       "en": "Allister Set",
       "fr": "Panoplie d'Allister",
       "de": "Allister-Set",
-      "es": "Set de Allister",
       "it": "Panoplia di Allister",
+      "es": "Set de Allister",
       "pt": "Conjunto de Allister"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Agility",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Range",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "MP Parry",
-          "value": 5,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "AP",
-          "value": 1,
+          "value": 40,
           "altStat": null
         },
         {
@@ -4939,15 +6854,38 @@
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Critical",
+          "value": 10,
           "altStat": null
         },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        }
+      ],
+      "3": [
         {
           "stat": "Agility",
           "value": 40,
           "altStat": null
-        }
+        },
+        {
+          "stat": "MP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -4957,47 +6895,20 @@
       "en": "Henual Set",
       "fr": "Panoplie d'Henual",
       "de": "Henual-Set",
-      "es": "Set de Henual",
       "it": "Panoplia di Henual",
+      "es": "Set de Henual",
       "pt": "Conjunto de Henual"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Strength",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Range",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Dodge",
-          "value": 5,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "Strength",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Intelligence",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Range",
-          "value": 1,
+          "value": 30,
           "altStat": null
         },
         {
@@ -5006,8 +6917,41 @@
           "altStat": null
         },
         {
-          "stat": "MP",
+          "stat": "Range",
           "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 100,
+          "altStat": null
+        }
+      ],
+      "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 100,
           "altStat": null
         }
       ]
@@ -5019,37 +6963,68 @@
       "en": "Count Razof Set",
       "fr": "Panoplie du Comte Razof",
       "de": "Graf Razoff-Set",
-      "es": "Set del conde Razof",
       "it": "Panoplia del Conte Razof",
+      "es": "Set del conde Razof",
       "pt": "Conjunto do Conde Razof"
     },
     "bonuses": {
       "2": [
         {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
           "stat": "Lock",
           "value": 10,
           "altStat": null
         },
         {
-          "stat": "AP Reduction",
-          "value": 5,
+          "stat": "Neutral Damage",
+          "value": 10,
           "altStat": null
         },
         {
-          "stat": "Heals",
+          "stat": "Earth Damage",
           "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 50,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Heals",
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "AP Reduction",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
         {
@@ -5058,8 +7033,33 @@
           "altStat": null
         },
         {
-          "stat": "Heals",
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
           "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 50,
           "altStat": null
         }
       ]
@@ -5071,69 +7071,85 @@
       "en": "Lost Set",
       "fr": "Panoplie Obscure",
       "de": "Dunkelset",
-      "es": "Set obscuro",
       "it": "Panoplia Oscura",
+      "es": "Set obscuro",
       "pt": "Conjunto Obscuro"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Strength",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "AP Parry",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Dodge",
-          "value": 5,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 20,
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": -7,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP Parry",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Dodge",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 20,
+          "stat": "Strength",
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Strength",
-          "value": 20,
+          "stat": "Chance",
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Dodge",
+          "value": 10,
           "altStat": null
-        }
+        },
+        {
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": -7,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -5143,32 +7159,20 @@
       "en": "Otomai Set",
       "fr": "Panoplie d'Otomaï",
       "de": "Otomaï-Set",
-      "es": "Set de Otomai",
       "it": "Panoplia di Otomai",
+      "es": "Set de Otomai",
       "pt": "Conjunto de Otomai"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Intelligence",
-          "value": 20,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Critical",
-          "value": 2,
-          "altStat": null
-        },
-        {
-          "stat": "Lock",
           "value": 5,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "AP",
-          "value": 1,
           "altStat": null
         },
         {
@@ -5177,13 +7181,31 @@
           "altStat": null
         },
         {
-          "stat": "Critical",
-          "value": 4,
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
-        },
+        }
+      ],
+      "3": [
         {
           "stat": "Intelligence",
           "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         }
       ]
@@ -5195,39 +7217,45 @@
       "en": "Glacial Set",
       "fr": "Panoplie Glaciale",
       "de": "Eiskaltes Set",
-      "es": "Set glacial",
       "it": "Panoplia Glaciale",
+      "es": "Set glacial",
       "pt": "Conjunto Glacial"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Chance",
-          "value": 50,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Critical Resistance",
           "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Damage",
+          "value": 30,
           "altStat": null
         }
       ],
       "3": [
         {
           "stat": "Chance",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Critical Resistance",
           "value": 25,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Pushback Damage",
+          "value": 30,
+          "altStat": null
+        },
+        { "stat": "MP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -5289,61 +7317,108 @@
       "en": "Sleet Set",
       "fr": "Frimanoplie",
       "de": "Raureifset",
-      "es": "Set congelado",
       "it": "Invernoplia",
+      "es": "Set congelado",
       "pt": "Conjunto Gelado"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Strength",
-          "value": 15,
+          "stat": "Intelligence",
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 15,
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 300,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Strength",
+          "stat": "Intelligence",
           "value": 30,
           "altStat": null
         },
         {
-          "stat": "Power",
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
           "value": 10,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 30,
+          "stat": "Air Damage",
+          "value": 10,
           "altStat": null
-        }
-      ],
-      "4": [
+        },
         {
-          "stat": "Power",
+          "stat": "Initiative",
+          "value": 300,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
           "value": 20,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null }
+      ],
+      "4": [
         {
-          "stat": "Chance",
+          "stat": "Intelligence",
           "value": 50,
           "altStat": null
         },
         {
-          "stat": "Strength",
+          "stat": "Agility",
           "value": 50,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Fire Damage",
+          "value": 15,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Air Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -5353,37 +7428,73 @@
       "en": "Chassulliers Set",
       "fr": "Panoplie des Chassouilleurs",
       "de": "Hinterwäldler-Set",
-      "es": "Set de los grescazadores",
       "it": "Panoplia dei Macciatori",
+      "es": "Set de los grescazadores",
       "pt": "Conjunto dos Caçamadores"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Critical Resistance",
-          "value": 50,
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
-          "value": 5,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 50,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Critical Resistance",
-          "value": 50,
+          "stat": "Air Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 50,
           "altStat": null
         }
       ]
@@ -5395,61 +7506,85 @@
       "en": "Hail Set",
       "fr": "Panoplie Grésil",
       "de": "Hagelset",
-      "es": "Set Granizado",
       "it": "Panoplia Nevischio",
+      "es": "Set Granizado",
       "pt": "Conjunto Granizo"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Intelligence",
-          "value": 15,
+          "stat": "Strength",
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 15,
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 300,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Intelligence",
+          "stat": "Strength",
           "value": 30,
           "altStat": null
         },
         {
-          "stat": "Agility",
+          "stat": "Chance",
           "value": 30,
           "altStat": null
         },
         {
-          "stat": "Power",
+          "stat": "Neutral Damage",
           "value": 10,
           "altStat": null
-        }
-      ],
-      "4": [
+        },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Earth Damage",
+          "value": 10,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 50,
+          "stat": "Water Damage",
+          "value": 10,
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 50,
+          "stat": "Initiative",
+          "value": 300,
           "altStat": null
         },
         {
-          "stat": "Power",
+          "stat": "Prospecting",
           "value": 20,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -5459,47 +7594,53 @@
       "en": "Danathor Set",
       "fr": "Panoplie de Danathor",
       "de": "Danathor-Set",
-      "es": "Set de Danathor",
       "it": "Panoplia di Danathor",
+      "es": "Set de Danathor",
       "pt": "Conjunto de Danathor"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Chance",
-          "value": 20,
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Prospecting",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "MP Parry",
-          "value": 4,
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Chance",
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "MP Parry",
-          "value": 8,
+          "stat": "Initiative",
+          "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Prospecting",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 40,
+          "value": 20,
           "altStat": null
         }
       ]
@@ -5511,59 +7652,65 @@
       "en": "Nevark Set",
       "fr": "Panoplie de Nevark",
       "de": "Newark-Set",
-      "es": "Set de Nevark",
       "it": "Panoplia di Nevark",
+      "es": "Set de Nevark",
       "pt": "Conjunto do Nevark"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Strength",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Dodge",
-          "value": 6,
+          "stat": "Critical Damage",
+          "value": -20,
           "altStat": null
         },
         {
           "stat": "MP Parry",
-          "value": 4,
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Dodge",
-          "value": 12,
-          "altStat": null
-        },
-        {
-          "stat": "MP Parry",
-          "value": 8,
+          "stat": "Strength",
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 40,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Strength",
-          "value": 40,
+          "stat": "Dodge",
+          "value": 10,
           "altStat": null
-        }
+        },
+        {
+          "stat": "MP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": -20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -5573,82 +7720,153 @@
       "en": "Ogivol Set",
       "fr": "Panoplie d'Ogivol",
       "de": "Ogivol-Set",
-      "es": "Set de Ogivol",
       "it": "Panoplia di Ogivol",
+      "es": "Set de Ogivol",
       "pt": "Conjunto de Ogivol"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Neutral Damage",
-          "value": 4,
+          "stat": "Strength",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Earth Damage",
-          "value": 4,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 4,
-          "altStat": null
-        },
-        {
-          "stat": "Water Damage",
-          "value": 4,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
+          "stat": "Chance",
           "value": 20,
           "altStat": null
         },
         {
           "stat": "Critical Resistance",
-          "value": 6,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "Air Damage",
-          "value": 8,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": -1,
+          "stat": "Critical",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 100,
           "altStat": null
         },
         {
           "stat": "Neutral Damage",
-          "value": 8,
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Earth Damage",
-          "value": 8,
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Water Damage",
-          "value": 8,
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "Wisdom",
+          "stat": "Air Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 300,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        }
+      ],
+      "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Critical Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
           "value": 40,
           "altStat": null
         },
         {
-          "stat": "Critical Resistance",
-          "value": 12,
+          "stat": "Chance",
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "AP",
+          "stat": "Strength",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
           "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 300,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         }
       ]
@@ -5660,40 +7878,40 @@
       "en": "Professor Xa Set",
       "fr": "Panoplie du Professeur Xa",
       "de": "Set von Professor Xa",
-      "es": "Set del profesor Xa",
       "it": "Panoplia del Professor Xa",
+      "es": "Set del profesor Xa",
       "pt": "Conjunto do Professor Xa"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Strength",
-          "value": 25,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 25,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 25,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 10,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "AP Reduction",
-          "value": 3,
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 3,
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 10,
           "altStat": null
         }
       ],
@@ -5714,60 +7932,50 @@
           "altStat": null
         },
         {
-          "stat": "Wisdom",
-          "value": 20,
-          "altStat": null
-        },
-        {
           "stat": "AP Reduction",
-          "value": 6,
+          "value": 7,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 6,
+          "value": 7,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": -1,
+          "stat": "Prospecting",
+          "value": 15,
           "altStat": null
         }
       ],
       "4": [
         {
           "stat": "Strength",
-          "value": 75,
+          "value": 80,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 75,
+          "value": 80,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 75,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 30,
+          "value": 80,
           "altStat": null
         },
         {
           "stat": "AP Reduction",
-          "value": 9,
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 9,
+          "value": 10,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": -1,
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         }
       ],
@@ -5788,28 +7996,18 @@
           "altStat": null
         },
         {
-          "stat": "Wisdom",
-          "value": 40,
-          "altStat": null
-        },
-        {
           "stat": "AP Reduction",
-          "value": 12,
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 12,
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": -1,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": -1,
+          "stat": "Prospecting",
+          "value": 30,
           "altStat": null
         }
       ]
@@ -5821,8 +8019,8 @@
       "en": "Fuji Snowfoux Set",
       "fr": "Panoplie de la Fuji Givrefoux",
       "de": "Fuji Eisfux - Set",
-      "es": "Set de Fuji Gélifux",
       "it": "Panoplia di Fuji Ghiacciopaz",
+      "es": "Set de Fuji Gélifux",
       "pt": "Conjunto da Fuji Gelifox"
     },
     "bonuses": {
@@ -5833,25 +8031,45 @@
           "altStat": null
         },
         {
-          "stat": "Initiative",
-          "value": 200,
+          "stat": "Strength",
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Critical",
-          "value": 2,
+          "stat": "Agility",
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Critical Damage",
-          "value": 10,
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 300,
           "altStat": null
         }
       ],
       "3": [
         {
           "stat": "Vitality",
-          "value": 150,
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 15,
           "altStat": null
         },
         {
@@ -5859,53 +8077,35 @@
           "value": 300,
           "altStat": null
         },
-        {
-          "stat": "Critical",
-          "value": 3,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Damage",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Range",
-          "value": 1,
-          "altStat": null
-        }
+        { "stat": "AP", "value": 1, "altStat": null }
       ],
       "4": [
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
         {
           "stat": "Vitality",
           "value": 200,
           "altStat": null
         },
         {
-          "stat": "Initiative",
-          "value": 400,
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Critical",
-          "value": 4,
+          "stat": "Agility",
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Critical Damage",
-          "value": 30,
+          "value": 25,
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Initiative",
+          "value": 500,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -5915,69 +8115,51 @@
       "en": "Kolosso Set",
       "fr": "Panoplie de Kolosso",
       "de": "Daxolossus-Set",
-      "es": "Set de Tejossus",
       "it": "Panoplia di Kolosso",
+      "es": "Set de Tejossus",
       "pt": "Conjunto do Kolosso"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Fire Damage",
-          "value": 12,
+          "stat": "Strength",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Air Damage",
-          "value": 12,
+          "stat": "Power",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Water Damage",
-          "value": 12,
+          "stat": "AP Parry",
+          "value": 7,
           "altStat": null
         },
-        {
-          "stat": "Lock",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Critical",
-          "value": 3,
-          "altStat": null
-        }
+        { "stat": "Lock", "value": 7, "altStat": null }
       ],
       "3": [
         {
-          "stat": "Fire Damage",
-          "value": 24,
+          "stat": "Strength",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Air Damage",
-          "value": 24,
+          "stat": "Power",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Water Damage",
-          "value": 24,
+          "stat": "AP Parry",
+          "value": 7,
           "altStat": null
         },
         {
           "stat": "Lock",
-          "value": 10,
+          "value": 7,
           "altStat": null
         },
-        {
-          "stat": "Critical",
-          "value": 6,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        }
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -5987,61 +8169,93 @@
       "en": "Stringsecticide Set",
       "fr": "Panoplie Tue-Mouche",
       "de": "Fliegentöter-Set",
-      "es": "Set Muscario",
       "it": "Panoplia Ammazzamosca",
+      "es": "Set Muscario",
       "pt": "Conjunto Mata-Mosca"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Wisdom",
-          "value": 5,
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         },
-        {
-          "stat": "Intelligence",
-          "value": 20,
-          "altStat": null
-        }
-      ],
-      "3": [
         {
           "stat": "Summons",
           "value": 1,
           "altStat": null
         },
         {
-          "stat": "Wisdom",
-          "value": 10,
+          "stat": "Heals",
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
+          "stat": "Prospecting",
           "value": 30,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": "Summons",
-          "value": 2,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 20,
           "altStat": null
         },
         {
           "stat": "Intelligence",
           "value": 40,
           "altStat": null
+        }
+      ],
+      "3": [
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
         },
         {
-          "stat": "AP",
+          "stat": "Prospecting",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
           "value": 1,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
+      ],
+      "4": [
+        {
+          "stat": "Intelligence",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "Summons",
+          "value": 2,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6051,61 +8265,78 @@
       "en": "Gladiator Bworker Set",
       "fr": "Panoplie du Bworker Gladiateur",
       "de": "GladiaBworker-Set",
-      "es": "Set de Bworker Gladiador",
       "it": "Panoplia del Bworker Gladiatore",
+      "es": "Set de Bworker Gladiador",
       "pt": "Conjunto do Bworker Gladiador"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Strength",
-          "value": 15,
+          "stat": "Intelligence",
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 15,
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Strength",
+          "stat": "Intelligence",
           "value": 30,
           "altStat": null
         },
         {
-          "stat": "Agility",
+          "stat": "Chance",
           "value": 30,
           "altStat": null
         },
         {
           "stat": "Critical",
-          "value": 2,
+          "value": 5,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ],
       "4": [
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
+          "stat": "Intelligence",
           "value": 50,
           "altStat": null
         },
         {
-          "stat": "Agility",
+          "stat": "Chance",
           "value": 50,
           "altStat": null
         },
         {
           "stat": "Critical",
-          "value": 4,
+          "value": 8,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6115,8 +8346,8 @@
       "en": "Borealis Set",
       "fr": "Panoplie de Boréale",
       "de": "Bohrealis-Set",
-      "es": "Set de Boreal",
       "it": "Panoplia di Boreale",
+      "es": "Set de Boreal",
       "pt": "Conjunto de Boreal"
     },
     "bonuses": {
@@ -6133,44 +8364,65 @@
         },
         {
           "stat": "Chance",
-          "value": 50,
+          "value": 70,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 50,
+          "value": 70,
           "altStat": null
         },
         {
           "stat": "Earth Damage",
-          "value": 10,
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Fire Damage",
-          "value": 10,
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Water Damage",
-          "value": 10,
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Air Damage",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "Critical",
-          "value": 3,
+          "value": 5,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "MP", "value": 1, "altStat": null },
         {
-          "stat": "Strength",
-          "value": 100,
+          "stat": "Air Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 120,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 120,
           "altStat": null
         },
         {
@@ -6179,45 +8431,41 @@
           "altStat": null
         },
         {
-          "stat": "Chance",
+          "stat": "Strength",
           "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Damage",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Fire Damage",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Water Damage",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Critical",
-          "value": 6,
           "altStat": null
         }
       ],
       "4": [
+        { "stat": "MP", "value": 1, "altStat": null },
         {
-          "stat": "Strength",
-          "value": 150,
+          "stat": "Air Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 170,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 170,
           "altStat": null
         },
         {
@@ -6226,43 +8474,8 @@
           "altStat": null
         },
         {
-          "stat": "Chance",
+          "stat": "Strength",
           "value": 150,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
-          "value": 150,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Damage",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Fire Damage",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Water Damage",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Critical",
-          "value": 9,
-          "altStat": null
-        },
-        {
-          "stat": "Range",
-          "value": 1,
           "altStat": null
         }
       ]
@@ -6274,59 +8487,76 @@
       "en": "Korriander Set",
       "fr": "Panoplie du Korriandre",
       "de": "Korriander-Set",
-      "es": "Set de Cil",
       "it": "Panoplia di Koriandoro",
+      "es": "Set de Cil",
       "pt": "Conjunto do Kwentro"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Agility",
-          "value": 10,
+          "stat": "AP Reduction",
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
           "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
+          "stat": "Critical Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
           "stat": "Agility",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "AP Reduction",
           "value": 5,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ],
       "4": [
-        {
-          "stat": "Agility",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 30,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "AP Reduction",
           "value": 10,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 15,
           "altStat": null
         }
       ]
@@ -6338,48 +8568,24 @@
       "en": "Shroom Set",
       "fr": "Panoplignon",
       "de": "Fungal-Set",
-      "es": "Set'As",
       "it": "Panoplignon",
+      "es": "Set'As",
       "pt": "Conjuntomelo"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Power (traps)",
-          "value": 25,
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 10,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "Power (traps)",
-          "value": 50,
+          "stat": "Air Damage",
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "Wisdom",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
-          "value": 20,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": "Power (traps)",
-          "value": 80,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
+          "stat": "Prospecting",
           "value": 20,
           "altStat": null
         },
@@ -6387,12 +8593,58 @@
           "stat": "Agility",
           "value": 40,
           "altStat": null
+        }
+      ],
+      "3": [
+        {
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
         },
         {
-          "stat": "AP",
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
           "value": 1,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
+      ],
+      "4": [
+        {
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 8,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6402,61 +8654,55 @@
       "en": "Berserker Bworker Set",
       "fr": "Panoplie du Bworker Berserker",
       "de": "BerserkBworker-Set",
-      "es": "Set de Bworker Berserker",
       "it": "Panoplia del Bworker Berserker",
+      "es": "Set de Bworker Berserker",
       "pt": "Conjunto do Bworker Berserker"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Intelligence",
-          "value": 15,
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 15,
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Chance",
+          "stat": "Strength",
           "value": 30,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
+          "stat": "Agility",
           "value": 30,
           "altStat": null
         },
         {
           "stat": "Critical",
-          "value": 2,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": "MP",
-          "value": 1,
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "Critical",
-          "value": 4,
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         },
-        {
-          "stat": "Intelligence",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 50,
-          "altStat": null
-        }
+        { "stat": "MP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6464,34 +8710,17 @@
     "id": "118",
     "name": {
       "en": "Ougaa Set",
-      "fr": "Panoplie Ougah",
+      "fr": "Panoplie du Ougah",
       "de": "Stinkeling-Set",
-      "es": "Set Ugah",
       "it": "Panoplia Ugah",
-      "pt": "Conjunto Ugah"
+      "es": "Set de Ugah",
+      "pt": "Conjunto de Ugah"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Damage",
-          "value": 2,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "Prospecting",
-          "value": 10,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "Damage",
-          "value": 4,
+          "stat": "Power",
+          "value": 30,
           "altStat": null
         },
         {
@@ -6501,24 +8730,12 @@
         },
         {
           "stat": "Wisdom",
-          "value": 20,
+          "value": 30,
           "altStat": null
-        }
-      ],
-      "4": [
+        },
         {
           "stat": "Damage",
-          "value": 6,
-          "altStat": null
-        },
-        {
-          "stat": "Prospecting",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 30,
+          "value": 5,
           "altStat": null
         },
         {
@@ -6526,6 +8743,62 @@
           "value": 1,
           "altStat": null
         }
+      ],
+      "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
+          "stat": "Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Wisdom",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 30,
+          "altStat": null
+        }
+      ],
+      "4": [
+        {
+          "stat": "Power",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Wisdom",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6535,15 +8808,25 @@
       "en": "K.O. Set",
       "fr": "Panoplie du K.O.",
       "de": "K.O.-Set",
-      "es": "Set de Kaos",
       "it": "Panoplia del Kappàos",
+      "es": "Set de Kaos",
       "pt": "Conjunto do K.O."
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Strength",
-          "value": 30,
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Damage",
+          "value": 20,
           "altStat": null
         },
         {
@@ -6552,18 +8835,8 @@
           "altStat": null
         },
         {
-          "stat": "Fire Damage",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Damage",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Neutral Damage",
-          "value": 5,
+          "stat": "Strength",
+          "value": 30,
           "altStat": null
         }
       ],
@@ -6579,25 +8852,21 @@
           "altStat": null
         },
         {
-          "stat": "Fire Damage",
+          "stat": "Pushback Damage",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
           "value": 5,
           "altStat": null
         },
         {
-          "stat": "Earth Damage",
-          "value": 5,
+          "stat": "AP Parry",
+          "value": 10,
           "altStat": null
         },
-        {
-          "stat": "Neutral Damage",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        }
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6607,8 +8876,8 @@
       "en": "Necrotick Set",
       "fr": "Panoplie Nécrotique",
       "de": "Nekroten-Set",
-      "es": "Set necrótico",
       "it": "Panoplia Necronsetto",
+      "es": "Set necrótico",
       "pt": "Conjunto dos Entomortis"
     },
     "bonuses": {
@@ -6624,7 +8893,7 @@
           "altStat": null
         },
         {
-          "stat": "Air Damage",
+          "stat": "Neutral Damage",
           "value": 5,
           "altStat": null
         },
@@ -6634,15 +8903,31 @@
           "altStat": null
         },
         {
-          "stat": "Neutral Damage",
+          "stat": "Air Damage",
           "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 7,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Strength",
-          "value": 30,
+          "stat": "Neutral Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 5,
           "altStat": null
         },
         {
@@ -6651,23 +8936,13 @@
           "altStat": null
         },
         {
-          "stat": "Air Damage",
-          "value": 5,
+          "stat": "Strength",
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Earth Damage",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Neutral Damage",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
+          "stat": "AP Reduction",
+          "value": 7,
           "altStat": null
         }
       ]
@@ -6679,8 +8954,8 @@
       "en": "Dremoan Set",
       "fr": "Panoplie de Dremoan",
       "de": "Dremoan-Set",
-      "es": "Set de Dremoan",
       "it": "Panoplia di Dremoan",
+      "es": "Set de Dremoan",
       "pt": "Conjunto do Dermoan"
     },
     "bonuses": {
@@ -6691,27 +8966,33 @@
           "altStat": null
         },
         {
+          "stat": "Pushback Resistance",
+          "value": 20,
+          "altStat": null
+        },
+        {
           "stat": "MP Parry",
-          "value": 5,
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
         {
           "stat": "Intelligence",
           "value": 40,
           "altStat": null
         },
         {
-          "stat": "MP Parry",
-          "value": 5,
+          "stat": "Pushback Resistance",
+          "value": 20,
           "altStat": null
-        }
+        },
+        {
+          "stat": "MP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6721,39 +9002,55 @@
       "en": "Funguset",
       "fr": "Panoplycélium",
       "de": "Mycel-Set",
-      "es": "Setiñón",
       "it": "Panoplicelio",
+      "es": "Setiñón",
       "pt": "Conjunto Fungo"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Strength",
-          "value": 10,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Damage",
-          "value": 2,
+          "stat": "Neutral Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
           "stat": "Strength",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Damage",
-          "value": 4,
+          "stat": "Neutral Damage",
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Earth Damage",
+          "value": 5,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6763,49 +9060,55 @@
       "en": "Undergrowth Set",
       "fr": "Panoplie des Sous-bois",
       "de": "Unterholz-Set",
-      "es": "Set del sotobosque",
       "it": "Panoplia dei Sottoboschi",
+      "es": "Set del sotobosque",
       "pt": "Conjunto do sub-bosque"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Chance",
-          "value": 15,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Damage",
-          "value": 2,
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "Critical",
-          "value": 2,
+          "stat": "Water Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Prospecting",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "Critical",
-          "value": 4,
-          "altStat": null
-        },
-        {
-          "stat": "Damage",
-          "value": 4,
-          "altStat": null
-        },
-        {
           "stat": "Chance",
-          "value": 30,
+          "value": 40,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Prospecting",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6815,43 +9118,36 @@
       "en": "Tengu Snowfoux Set",
       "fr": "Panoplie du Tengu Givrefoux",
       "de": "Tengu Eisfux - Set",
-      "es": "Set de Tengu Gélifux",
       "it": "Panoplia di Tengu Ghiacciopaz",
+      "es": "Set de Tengu Gélifux",
       "pt": "Conjunto do Tengu Gelifox"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Intelligence",
-          "value": 10,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
           "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 5,
           "altStat": null
         }
       ],
       "3": [
         {
           "stat": "Intelligence",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "MP Parry",
-          "value": 5,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": "Intelligence",
           "value": 30,
           "altStat": null
         },
@@ -6866,10 +9162,34 @@
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Dodge",
+          "value": 5,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
+      ],
+      "4": [
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6879,46 +9199,78 @@
       "en": "Guten Tak Set",
       "fr": "Panoplie de Guten Tak",
       "de": "Guten Tark - Set",
-      "es": "Set de Gwen Astarde",
       "it": "Panoplia di Puon Ciorno",
+      "es": "Set de Gwen Astarde",
       "pt": "Conjunto de Guten Tak"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Strength",
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Vitality",
-          "value": 50,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Chance",
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Vitality",
           "value": 100,
           "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 5,
+          "altStat": null
         }
+      ],
+      "3": [
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Vitality",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 5,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ],
       "4": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Strength",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Vitality",
           "value": 150,
           "altStat": null
-        }
+        },
+        {
+          "stat": "AP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -6928,8 +9280,8 @@
       "en": "XLII Set",
       "fr": "Panoplie de XLII",
       "de": "XLII-Set",
-      "es": "Set de XLII",
       "it": "Panoplia di XLII",
+      "es": "Set de XLII",
       "pt": "Conjunto de XLII"
     },
     "bonuses": {
@@ -6945,6 +9297,34 @@
           "altStat": null
         },
         {
+          "stat": "% Air Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "Lock", "value": 5, "altStat": null }
+      ],
+      "3": [
+        {
           "stat": "% Water Resistance",
           "value": 5,
           "altStat": null
@@ -6956,18 +9336,6 @@
         },
         {
           "stat": "% Air Resistance",
-          "value": 5,
-          "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "% Neutral Resistance",
           "value": 5,
           "altStat": null
         },
@@ -6977,20 +9345,22 @@
           "altStat": null
         },
         {
-          "stat": "% Air Resistance",
+          "stat": "% Neutral Resistance",
           "value": 5,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "% Fire Resistance",
-          "value": 5,
+          "stat": "Agility",
+          "value": 20,
           "altStat": null
         },
         {
-          "stat": "% Water Resistance",
-          "value": 5,
+          "stat": "Strength",
+          "value": 20,
           "altStat": null
-        }
+        },
+        { "stat": "Lock", "value": 5, "altStat": null }
       ]
     }
   },
@@ -7000,8 +9370,8 @@
       "en": "Siks-T Set",
       "fr": "Panoplie de Soissanth",
       "de": "Gizesch-Set",
-      "es": "Set de sesenth",
       "it": "Panoplia di Sessanth",
+      "es": "Set de sesenth",
       "pt": "Conjunto de Secentah"
     },
     "bonuses": {
@@ -7020,16 +9390,16 @@
           "stat": "Chance",
           "value": 30,
           "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
+          "stat": "Chance",
           "value": 30,
           "altStat": null
         },
@@ -7039,8 +9409,14 @@
           "altStat": null
         },
         {
-          "stat": "Chance",
+          "stat": "Strength",
           "value": 30,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Critical",
+          "value": 5,
           "altStat": null
         }
       ]
@@ -7052,29 +9428,55 @@
       "en": "Wurmlord Set",
       "fr": "Pernoplie",
       "de": "Vater Wurm-Set",
-      "es": "Set de Anelidón",
       "it": "Panoplia del Pozzo",
+      "es": "Set de Anelidón",
       "pt": "Conjunto de Ver Medo"
     },
     "bonuses": {
       "2": [
         {
+          "stat": "Strength",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 5,
+          "altStat": null
+        },
+        {
           "stat": "Dodge",
-          "value": 25,
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Dodge",
-          "value": 25,
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "AP Parry",
+          "value": 5,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Dodge",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7084,29 +9486,65 @@
       "en": "Worm Set",
       "fr": "Vernoplie",
       "de": "Grünes Set",
-      "es": "Set gusanesco",
       "it": "Panoplia di Sirlak",
+      "es": "Set gusanesco",
       "pt": "Conjunto de Verme"
     },
     "bonuses": {
       "2": [
         {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 5,
+          "altStat": null
+        },
+        {
           "stat": "Critical",
-          "value": 10,
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Critical",
-          "value": 10,
+          "value": 5,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Heals",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7116,47 +9554,43 @@
       "en": "Set of the Prophets",
       "fr": "Panoplie des Prophètes",
       "de": "Set des Propheten",
-      "es": "Set de los profetas",
       "it": "Panoplia dei Profeti",
+      "es": "Set de los profetas",
       "pt": "Conjunto dos Profetas"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Intelligence",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
-          "value": 3,
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Intelligence",
-          "value": 40,
+          "stat": "MP Reduction",
+          "value": 10,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Chance",
-          "value": 40,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "MP Reduction",
-          "value": 6,
+          "stat": "Intelligence",
+          "value": 30,
           "altStat": null
         }
       ]
@@ -7168,29 +9602,22 @@
       "en": "Sovereign Set",
       "fr": "Panoplie Souveraine",
       "de": "Lehnsherren-Set",
-      "es": "Set del soberano",
       "it": "Panoplia Sovrana",
+      "es": "Set del soberano",
       "pt": "Conjunto Soberano"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Wisdom",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "Prospecting",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Vitality",
+          "stat": "Agility",
           "value": 30,
           "altStat": null
-        }
-      ],
-      "3": [
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
         {
           "stat": "Wisdom",
           "value": 20,
@@ -7202,15 +9629,38 @@
           "altStat": null
         },
         {
-          "stat": "Vitality",
-          "value": 60,
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        }
+      ],
+      "3": [
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Wisdom",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 10,
           "altStat": null
         },
         {
           "stat": "Range",
           "value": 1,
           "altStat": null
-        }
+        },
+        { "stat": "MP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7220,49 +9670,76 @@
       "en": "Obsidemon Set",
       "fr": "Panoplie de l'Obsidiantre",
       "de": "Obsidianter-Set",
-      "es": "Set de Obsidiantre",
       "it": "Panoplia di Ossidiante",
+      "es": "Set de Obsidiantre",
       "pt": "Conjunto do Obsidemônio"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Strength",
-          "value": 10,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
           "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 5,
           "altStat": null
         }
       ],
       "3": [
         {
           "stat": "Strength",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Pushback Resistance",
+          "value": 10,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Dodge",
+          "value": 5,
+          "altStat": null
+        },
+        { "stat": "MP", "value": 1, "altStat": null }
       ],
       "4": [
+        { "stat": "MP", "value": 1, "altStat": null },
         {
-          "stat": "Strength",
-          "value": 30,
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 20,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 30,
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
@@ -7273,6 +9750,11 @@
       ],
       "5": [
         {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
           "stat": "Strength",
           "value": 40,
           "altStat": null
@@ -7283,10 +9765,17 @@
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 2,
+          "stat": "Pushback Resistance",
+          "value": 20,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "MP", "value": 1, "altStat": null },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7296,47 +9785,43 @@
       "en": "Ush Set",
       "fr": "Panoplie de Ush",
       "de": "Ush-Set",
-      "es": "Set de Ush",
       "it": "Panoplia di Ush",
+      "es": "Set de Ush",
       "pt": "Conjunto do Ush"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Intelligence",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Pushback Damage",
-          "value": 10,
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Intelligence",
+          "stat": "Pushback Damage",
           "value": 20,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Pushback Damage",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Intelligence",
+          "value": 30,
           "altStat": null
         }
       ]
@@ -7348,39 +9833,45 @@
       "en": "Kanazure Set",
       "fr": "Panoplie du Kaniblou",
       "de": "Kaniguar-Set",
-      "es": "Set de kanublú",
       "it": "Panoplia del Kaniblù",
+      "es": "Set de kanublú",
       "pt": "Conjunto do Kaniblu"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Chance",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Dodge",
+          "stat": "AP Reduction",
           "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "AP Parry",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
           "stat": "Chance",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Dodge",
+          "stat": "AP Reduction",
           "value": 5,
           "altStat": null
-        }
+        },
+        {
+          "stat": "AP Parry",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7390,8 +9881,8 @@
       "en": "Celestial Swashbuckler Set",
       "fr": "Panoplie du Bretteur Céleste",
       "de": "Himmlischer Haudegen - Set",
-      "es": "Set de espadachín celeste",
       "it": "Panoplia dello Spadaccino Celeste",
+      "es": "Set de espadachín celeste",
       "pt": "Conjunto do Espadachim Celeste"
     },
     "bonuses": {
@@ -7407,7 +9898,7 @@
           "altStat": null
         },
         {
-          "stat": "Air Resistance",
+          "stat": "Fire Resistance",
           "value": 10,
           "altStat": null
         },
@@ -7417,24 +9908,34 @@
           "altStat": null
         },
         {
-          "stat": "Fire Resistance",
+          "stat": "Air Resistance",
           "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
           "stat": "Neutral Resistance",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "Air Resistance",
           "value": 10,
           "altStat": null
         },
@@ -7444,15 +9945,41 @@
           "altStat": null
         },
         {
+          "stat": "Fire Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
           "stat": "Water Resistance",
           "value": 10,
           "altStat": null
         },
         {
-          "stat": "Fire Resistance",
+          "stat": "Air Resistance",
           "value": 10,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7462,39 +9989,55 @@
       "en": "Weremoggies Set",
       "fr": "Panoplie des Matougarous",
       "de": "Werkater-Set",
-      "es": "Set de los micholobos",
       "it": "Panoplia dei Mici Mannari",
+      "es": "Set de los micholobos",
       "pt": "Conjunto dos Lobichanos"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Critical",
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
           "value": 5,
           "altStat": null
         },
         {
-          "stat": "Vitality",
-          "value": 50,
+          "stat": "Critical",
+          "value": 5,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Critical",
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "MP Reduction",
           "value": 5,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Critical",
+          "value": 5,
           "altStat": null
         },
-        {
-          "stat": "Vitality",
-          "value": 50,
-          "altStat": null
-        }
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7502,41 +10045,47 @@
     "id": "327",
     "name": {
       "en": "Orfan Set",
-      "fr": "Panoplie de l’Orfélin",
+      "fr": "Panoplie de l'Orfélin",
       "de": "Goldeoparden-Set",
-      "es": "Set de huerfelino",
       "it": "Panoplia dell'Infelino",
+      "es": "Set de huerfelino",
       "pt": "Conjunto do Orfelino"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Agility",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
           "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Damage",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
           "stat": "Agility",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
           "value": 5,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Pushback Damage",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7546,125 +10095,128 @@
       "en": "Minotot Set",
       "fr": "Panoplie du Minotot",
       "de": "Minotot-Set",
-      "es": "Set del Minotot",
       "it": "Panoplia del Minotot",
+      "es": "Set del Minotot",
       "pt": "Conjunto do Minotot"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Intelligence",
-          "value": 10,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 10,
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Prospecting",
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Heals",
-          "value": 1,
+          "value": 15,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "MP", "value": 1, "altStat": null },
         {
-          "stat": "Intelligence",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 20,
+          "stat": "Prospecting",
+          "value": 15,
           "altStat": null
         },
         {
           "stat": "Heals",
-          "value": 2,
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
           "altStat": null
         }
       ],
       "4": [
+        { "stat": "MP", "value": 1, "altStat": null },
         {
-          "stat": "Intelligence",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 30,
+          "stat": "Prospecting",
+          "value": 20,
           "altStat": null
         },
         {
           "stat": "Heals",
-          "value": 3,
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 40,
           "altStat": null
         }
       ],
       "5": [
         {
+          "stat": "Range",
+          "value": 1,
+          "altStat": null
+        },
+        {
           "stat": "Intelligence",
-          "value": 40,
+          "value": 50,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 40,
+          "value": 50,
           "altStat": null
         },
         {
           "stat": "Heals",
-          "value": 4,
+          "value": 25,
           "altStat": null
         },
         {
-          "stat": "Wisdom",
-          "value": 10,
+          "stat": "Prospecting",
+          "value": 25,
           "altStat": null
-        }
+        },
+        { "stat": "MP", "value": 1, "altStat": null }
       ],
       "6": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        { "stat": "MP", "value": 1, "altStat": null },
         {
-          "stat": "Intelligence",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 50,
-          "altStat": null
-        },
-        {
-          "stat": "Heals",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 20,
-          "altStat": null
-        }
-      ],
-      "7": [
-        {
-          "stat": "Intelligence",
-          "value": 60,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 60,
-          "altStat": null
-        },
-        {
-          "stat": "Heals",
-          "value": 6,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
+          "stat": "Prospecting",
           "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 60,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 60,
           "altStat": null
         },
         {
@@ -7681,103 +10233,93 @@
       "en": "Grozilla Set",
       "fr": "Panoplie de Grozilla",
       "de": "Grozilla-Set",
-      "es": "Set de Grozilla",
       "it": "Panoplia di Grozilla",
+      "es": "Set de Grozilla",
       "pt": "Conjunto de Grozilla"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Vitality",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 10,
+          "stat": "Dodge",
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Air Damage",
-          "value": 4,
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Water Damage",
-          "value": 4,
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "Dodge",
-          "value": 3,
+          "stat": "Chance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Air Damage",
-          "value": 8,
-          "altStat": null
-        },
-        {
-          "stat": "Water Damage",
-          "value": 8,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
+          "stat": "Agility",
           "value": 20,
           "altStat": null
         },
         {
-          "stat": "Vitality",
-          "value": 80,
+          "stat": "Chance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 6,
+          "value": 5,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ],
       "4": [
         {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Title: Legend Hunter"],
-            "fr": ["Titre : Chasseur de Légendes"],
-            "de": ["Titel: Legenden-Jäger"],
-            "es": ["Título: Cazador de Leyendas."],
-            "it": ["Titolo: Cacciatore di Leggende"],
-            "pt": ["Título: Caçador de Lendas"]
-          }
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 10,
+          "altStat": null
         },
         {
           "stat": "Dodge",
           "value": 10,
           "altStat": null
         },
-        {
-          "stat": "Air Damage",
-          "value": 12,
-          "altStat": null
-        },
-        {
-          "stat": "Water Damage",
-          "value": 12,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Vitality",
-          "value": 120,
-          "altStat": null
-        }
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7787,22 +10329,33 @@
       "en": "Zothulist Set",
       "fr": "Panoplie du Zothuliste",
       "de": "Set des zothigen Zoths",
-      "es": "Set zothulista",
       "it": "Panoplia del Zothulista",
+      "es": "Set zothulista",
       "pt": "Conjunto do Zothulista"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Intelligence",
-          "value": 25,
+          "value": 20,
           "altStat": null
         },
         {
           "stat": "Strength",
-          "value": 25,
+          "value": 30,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Vitality",
+          "value": 150,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7812,49 +10365,48 @@
       "en": "Buck Anear Set",
       "fr": "Panoplie de Ben le Ripate",
       "de": "Set von Ben dem Ripaten",
-      "es": "Set de Ben el Ripata",
       "it": "Panoplia di Ben il Ripata",
+      "es": "Set de Ben el Ripata",
       "pt": "Conjunto do Ben, o Ripata"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Agility",
-          "value": 10,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": -5,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
           "value": 10,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Agility",
-          "value": 20,
+          "stat": "Dodge",
+          "value": -5,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Critical Resistance",
+          "stat": "Lock",
           "value": 5,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": "Agility",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Intelligence",
-          "value": 30,
           "altStat": null
         },
         {
@@ -7863,10 +10415,48 @@
           "altStat": null
         },
         {
-          "stat": "Range",
-          "value": 1,
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
           "altStat": null
         }
+      ],
+      "4": [
+        {
+          "stat": "Critical",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": -5,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7876,20 +10466,31 @@
       "en": "Black Hornet Set",
       "fr": "Panoplie du Frelon Noir",
       "de": "Set der Schwarzen Hornisse",
-      "es": "Set de Los Abejorros Negros",
       "it": "Panoplia di Black Hornet",
+      "es": "Set de Los Abejorros Negros",
       "pt": "Conjunto do Vespa Negra"
     },
     "bonuses": {
       "2": [
+        { "stat": "MP", "value": 1, "altStat": null },
         {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Dodge",
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "Dodge",
-          "value": 10,
+          "stat": "Range",
+          "value": -1,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 20,
           "altStat": null
         }
       ]
@@ -7901,52 +10502,72 @@
       "en": "Cantile Set",
       "fr": "Panoplie de Cantile",
       "de": "Bürgherr-Set",
-      "es": "Set de Lario",
       "it": "Panoplia di Lorata",
+      "es": "Set de Lario",
       "pt": "Conjunto de Berna"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Neutral Damage",
-          "value": 3,
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Earth Damage",
-          "value": 3,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 3,
-          "altStat": null
-        },
-        {
-          "stat": "Critical",
-          "value": 3,
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Lock",
-          "value": 2,
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Critical",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 20,
           "altStat": null
         }
       ],
       "3": [
         {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 20,
+          "altStat": null
+        },
+        {
           "stat": "Neutral Damage",
-          "value": 6,
+          "value": 5,
           "altStat": null
         },
         {
           "stat": "Earth Damage",
-          "value": 6,
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "Air Damage",
-          "value": 6,
+          "stat": "Lock",
+          "value": 5,
           "altStat": null
         },
         {
@@ -7955,13 +10576,24 @@
           "altStat": null
         },
         {
-          "stat": "Lock",
-          "value": 3,
+          "stat": "Air Damage",
+          "value": 5,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ],
       "4": [
         {
+          "stat": "Agility",
+          "value": 70,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
           "stat": "Neutral Damage",
           "value": 10,
           "altStat": null
@@ -7972,20 +10604,21 @@
           "altStat": null
         },
         {
-          "stat": "Air Damage",
+          "stat": "Lock",
           "value": 10,
           "altStat": null
         },
         {
           "stat": "Critical",
-          "value": 7,
+          "value": 8,
           "altStat": null
         },
         {
-          "stat": "Lock",
-          "value": 5,
+          "stat": "Air Damage",
+          "value": 10,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -7995,37 +10628,68 @@
       "en": "Harpy Pirate Set",
       "fr": "Panoplie du Harpirate",
       "de": "Phantomharpiraten-Set",
-      "es": "Set de Harpirata",
       "it": "Panoplia del Fantarpione",
+      "es": "Set de Harpirata",
       "pt": "Conjunto do Arpirata"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "% Neutral Resistance",
-          "value": 6,
+          "stat": "Water Resistance",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "% Earth Resistance",
-          "value": 6,
+          "stat": "Fire Resistance",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "% Fire Resistance",
-          "value": 6,
+          "stat": "Neutral Resistance",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "% Water Resistance",
-          "value": 6,
+          "stat": "Earth Resistance",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "% Air Resistance",
-          "value": 6,
+          "stat": "Air Resistance",
+          "value": 15,
           "altStat": null
-        }
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Resistance",
+          "value": 15,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Damage",
+          "value": 8,
+          "altStat": null
+        },
+        {
+          "stat": "Air Damage",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        { "stat": "MP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -8035,8 +10699,8 @@
       "en": "Zatoishwan Set",
       "fr": "Panoplie de Zatoïshwan",
       "de": "Zatoïshwan-Set",
-      "es": "Set de Zatoïshwan",
       "it": "Panoplia di Zatoishwan",
+      "es": "Set de Zatoïshwan",
       "pt": "Conjunto do Zatoishwan"
     },
     "bonuses": {
@@ -8055,12 +10719,18 @@
           "stat": "Lock",
           "value": 5,
           "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 10,
+          "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Lock",
-          "value": 5,
+          "stat": "Strength",
+          "value": 30,
           "altStat": null
         },
         {
@@ -8069,13 +10739,13 @@
           "altStat": null
         },
         {
-          "stat": "Strength",
-          "value": 30,
+          "stat": "Lock",
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "MP Parry",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -8087,47 +10757,43 @@
       "en": "Powa Drhell Set",
       "fr": "Panoplie du Père Phorreur",
       "de": "Griesgramratt-Set",
-      "es": "Set de papatroz",
       "it": "Panoplia del Papà Trapalpotto",
+      "es": "Set de papatroz",
       "pt": "Conjunto do Papatroz"
     },
     "bonuses": {
       "2": [
         {
           "stat": "Chance",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Lock",
-          "value": 5,
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Lock",
-          "value": 5,
+          "stat": "Chance",
+          "value": 30,
           "altStat": null
         },
         {
           "stat": "Intelligence",
-          "value": 20,
+          "value": 30,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Lock",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -8362,127 +11028,30 @@
       "en": "Contrabanned Set",
       "fr": "Panoplie Contrebandière",
       "de": "Schmuggler-Set",
-      "es": "Set de contrabandista",
       "it": "Panoplia Contrabbandiera",
+      "es": "Set de contrabandista",
       "pt": "Conjunto Contrabandista"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Strength",
-          "value": 30,
-          "altStat": null
-        },
-        {
           "stat": "Earth Damage",
           "value": 10,
           "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "Strength",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Damage",
-          "value": 10,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Robbery no longer requires a line of sight"],
-            "fr": ["Désactive la ligne de vue du sort Brigandage"],
-            "de": ["Deaktiviert die Sichtlinie für den Zauber Räubern"],
-            "es": ["Desactiva la línea de visión del hechizo Bandolerismo"],
-            "it": ["Disattiva la linea di tiro dell'incantesimo Brigandeggio"],
-            "pt": ["Desativa a linha de visão do feitiço Bandoleirismo"]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["25 Damage on the spell: Contraband"],
-            "fr": ["25 Dommages sur le sort Contrebande"],
-            "de": ["25 Schaden beim Zauber: Schmuggelei"],
-            "es": ["25 daños del hechizo Contrabando"],
-            "it": ["25 Danni sull'incantesimo Contrabbando"],
-            "pt": ["25 danos para o feitiço Contrabando"]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Tax is no longer linear"],
-            "fr": ["Désactive le lancer en ligne du sort Taxe"],
-            "de": [
-              "Deaktiviert die lineare Wirkungsweise für den Zauber Versteuerung"
-            ],
-            "es": ["Desactiva el lanzamiento en línea recta del hechizo Tasa"],
-            "it": ["Disattiva il lancio in linea dell'incantesimo Tassa"],
-            "pt": ["Desativa o lançamento em linha do feitiço Taxa"]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Reduces the Leasing spell's AP cost by 1"],
-            "fr": ["Réduit de 1 le coût en PA du sort Affermage"],
-            "de": ["Senkt die AP-Kosten des Zaubers Pacht um 1"],
-            "es": [
-              "Reduce en 1 el número de PA que cuesta el hechizo Arrendamiento."
-            ],
-            "it": [
-              "Diminuisce di 1 il costo di PA dell'incantesimo Affermanza"
-            ],
-            "pt": ["Reduz em 1 o custo de PA do feitiço Arrendamento"]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Increases the Salt Tax spell's maximum range by 2"],
-            "fr": ["Augmente la portée maximale du sort Gabelle de 2"],
-            "de": [
-              "Erhöht die maximale Reichweite des Zauberspruchs Salzsteuer um 2."
-            ],
-            "es": ["Aumenta en 2 el alcance máximo del hechizo Gabela."],
-            "it": ["Aumenta la Portata massima dell'incantesimo Gabella di 2"],
-            "pt": ["Aumenta o alcance máximo do feitiço Taxa de Sal em 2"]
-          }
         },
         {
           "stat": "Strength",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Earth Damage",
-          "value": 10,
+          "stat": "% Air Resistance",
+          "value": -5,
           "altStat": null
         },
         {
           "stat": "% Earth Resistance",
-          "value": 15,
+          "value": 5,
           "altStat": null
         }
       ]
@@ -10363,265 +12932,67 @@
     }
   },
   {
-    "id": "250",
+    "id": "455",
     "name": {
-      "en": "Submersible Set",
-      "fr": "Panoplie Submersible",
-      "de": "Tauch-Set",
-      "es": "Set sumergible",
-      "it": "Panoplia Sommergibile",
-      "pt": "Conjunto Submarino"
+      "en": "Submerged Set",
+      "fr": "Panoplie Submergée",
+      "de": "Versunkenes Set",
+      "it": "Panoplia Annegata",
+      "es": "Set sumergido",
+      "pt": "Conjunto Submerso"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Agility",
+          "stat": "AP Parry",
           "value": 20,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 20,
+          "stat": "Pushback Resistance",
+          "value": 25,
           "altStat": null
         },
         {
-          "stat": "Strength",
-          "value": 20,
+          "stat": "Critical",
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "Chance",
-          "value": 20,
+          "stat": "Air Damage",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "Wisdom",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Vitality",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Damage",
-          "value": 3,
-          "altStat": null
-        },
-        {
-          "stat": "Heals",
-          "value": 3,
-          "altStat": null
-        },
-        {
-          "stat": "Prospecting",
+          "stat": "% Fire Resistance",
           "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Agility",
-          "value": 40,
+          "stat": "Critical",
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 40,
+          "stat": "Air Damage",
+          "value": 15,
           "altStat": null
         },
         {
-          "stat": "Strength",
-          "value": 40,
+          "stat": "Pushback Resistance",
+          "value": 25,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "Chance",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Vitality",
-          "value": 200,
-          "altStat": null
-        },
-        {
-          "stat": "Damage",
-          "value": 7,
-          "altStat": null
-        },
-        {
-          "stat": "Heals",
-          "value": 7,
-          "altStat": null
-        },
-        {
-          "stat": "Prospecting",
+          "stat": "AP Parry",
           "value": 20,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": "Agility",
-          "value": 70,
-          "altStat": null
-        },
-        {
-          "stat": "Intelligence",
-          "value": 70,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
-          "value": 70,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 70,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 70,
-          "altStat": null
-        },
-        {
-          "stat": "Vitality",
-          "value": 500,
-          "altStat": null
-        },
-        {
-          "stat": "Damage",
-          "value": 12,
-          "altStat": null
-        },
-        {
-          "stat": "Heals",
-          "value": 12,
-          "altStat": null
-        },
-        {
-          "stat": "Summons",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Prospecting",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "% Air Resistance",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "% Water Resistance",
-          "value": 5,
           "altStat": null
         },
         {
           "stat": "% Fire Resistance",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "% Neutral Resistance",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "% Earth Resistance",
-          "value": 5,
-          "altStat": null
-        }
-      ],
-      "5": [
-        {
-          "stat": "Agility",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Intelligence",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Wisdom",
-          "value": 100,
-          "altStat": null
-        },
-        {
-          "stat": "Vitality",
-          "value": 800,
-          "altStat": null
-        },
-        {
-          "stat": "Damage",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "Heals",
-          "value": 20,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Summons",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Prospecting",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "% Air Resistance",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "% Water Resistance",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "% Fire Resistance",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "% Neutral Resistance",
-          "value": 10,
-          "altStat": null
-        },
-        {
-          "stat": "% Earth Resistance",
           "value": 10,
           "altStat": null
         }
@@ -10634,147 +13005,30 @@
       "en": "Infernal Set",
       "fr": "Panoplie Infernale",
       "de": "Inferno-Set",
-      "es": "Set infernal",
       "it": "Panoplia Infernale",
+      "es": "Set infernal",
       "pt": "Conjunto Infernal"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Intelligence",
-          "value": 30,
-          "altStat": null
-        },
-        {
           "stat": "Fire Damage",
           "value": 10,
           "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "Intelligence",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Fire Damage",
-          "value": 10,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": [
-              "Increases the maximum number of times Infernal Storm can be cast per turn by 1"
-            ],
-            "fr": [
-              "Augmente de 1 le nombre de lancer maximal par tour du sort Tempête Infernale"
-            ],
-            "de": [
-              "Erhöht das Maximum an Zaubern pro Runde für den Zauber Höllensturm um 1"
-            ],
-            "es": [
-              "+1 al número máximo de veces por turno que se puede lanzar el hechizo Tempestad Infernal"
-            ],
-            "it": [
-              "Aumenta di 1 il numero di lanci massimi per turno dell'incantesimo Tempesta Infernale"
-            ],
-            "pt": [
-              "Aumenta em 1 o número máximo de lançamentos por turno do feitiço Tempestade Infernal"
-            ]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["30 Damage on the spell: Infernal Flames"],
-            "fr": ["30 Dommages sur le sort Flammes Infernales"],
-            "de": ["30 Schaden beim Zauber: Flammen der Hölle"],
-            "es": ["30 daños del hechizo Llamas Infernales"],
-            "it": ["30 Danni sull'incantesimo Fiamme Infernali"],
-            "pt": ["30 danos para o feitiço Chamas Infernais"]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Mind-numbing Flames no longer requires a line of sight"],
-            "fr": ["Désactive la ligne de vue du sort Flammes Abrutissantes"],
-            "de": [
-              "Deaktiviert die Sichtlinie für den Zauber Flammende Dummheit"
-            ],
-            "es": [
-              "Desactiva la línea de visión del hechizo Llamas Entontecedoras"
-            ],
-            "it": [
-              "Disattiva la linea di tiro dell'incantesimo Fiamme Estenuanti"
-            ],
-            "pt": [
-              "Desativa a linha de visão do feitiço Chamas Entorpecedoras de Mentes"
-            ]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Treacherous Flames no longer requires a line of sight"],
-            "fr": ["Désactive la ligne de vue du sort Flammes de Traîtrise"],
-            "de": [
-              "Deaktiviert die Sichtlinie für den Zauber Flammender Verrat"
-            ],
-            "es": [
-              "Desactiva la línea de visión del hechizo Llamas de la Traición"
-            ],
-            "it": [
-              "Disattiva la linea di tiro dell'incantesimo Fiamme di Tradimento"
-            ],
-            "pt": ["Desativa a linha de visão do feitiço Chamas Traidoras"]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Heat Theft no longer requires a line of sight"],
-            "fr": ["Désactive la ligne de vue du sort Vol de Chaleur"],
-            "de": ["Deaktiviert die Sichtlinie für den Zauber Wärmeraub"],
-            "es": ["Desactiva la línea de visión del hechizo Robo de Calor"],
-            "it": [
-              "Disattiva la linea di tiro dell'incantesimo Furto di Calore"
-            ],
-            "pt": ["Desativa a linha de visão do feitiço Roubo de Calor"]
-          }
         },
         {
           "stat": "Intelligence",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Fire Damage",
-          "value": 10,
+          "stat": "% Water Resistance",
+          "value": -5,
           "altStat": null
         },
         {
           "stat": "% Fire Resistance",
-          "value": 15,
+          "value": 5,
           "altStat": null
         }
       ]
@@ -10786,164 +13040,31 @@
       "en": "Fluvial Set",
       "fr": "Panoplie Fluviale",
       "de": "Fluss-Set",
-      "es": "Set fluvial",
       "it": "Panoplia Fluviale",
+      "es": "Set fluvial",
       "pt": "Conjunto Fluvial"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Chance",
-          "value": 30,
-          "altStat": null
-        },
-        {
           "stat": "Water Damage",
           "value": 10,
           "altStat": null
-        }
-      ],
-      "3": [
+        },
         {
           "stat": "Chance",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Water Damage",
-          "value": 10,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": "Chance",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Water Damage",
-          "value": 10,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "% Water Resistance",
-          "value": 15,
+          "value": 5,
           "altStat": null
         },
         {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": [
-              "Increases the Summoning of Bulbydro spell's maximum range by 2"
-            ],
-            "fr": [
-              "Augmente la portée maximale du sort Invocation de Bulbeau de 2"
-            ],
-            "de": [
-              "Erhöht die maximale Reichweite des Zauberspruchs Bulbchön beschwören um 2."
-            ],
-            "es": [
-              "Aumenta en 2 el alcance máximo del hechizo Invocación de Bulbello."
-            ],
-            "it": [
-              "Aumenta la Portata massima dell'incantesimo Evocazione di Bulbello di 2"
-            ],
-            "pt": [
-              "Aumenta o alcance máximo do feitiço Invocação de Bulbydro em 2"
-            ]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": [
-              "Increases the maximum number of times Boiling Water can be cast per target by 1"
-            ],
-            "fr": [
-              "Augmente de 1 le nombre de lancer maximal par cible du sort Eau Bouillante"
-            ],
-            "de": [
-              "Erhöht das Maximum an Zaubern pro Ziel für den Zauber Kochendes Wasser um 1"
-            ],
-            "es": [
-              "+1 al número máximo de veces que se le puede lanzar el hechizo Agua Hirviendo a un mismo objetivo"
-            ],
-            "it": [
-              "Aumenta di 1 il numero di lanci massimi per bersaglio dell'incantesimo Acqua Bollente"
-            ],
-            "pt": [
-              "Aumenta em 1 o número máximo de lançamentos por alvo do feitiço Água Fervente"
-            ]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Increases the Stagnant Water spell's maximum range by 2"],
-            "fr": ["Augmente la portée maximale du sort Eau Stagnante de 2"],
-            "de": [
-              "Erhöht die maximale Reichweite des Zauberspruchs Stilles Wasser um 2."
-            ],
-            "es": [
-              "Aumenta en 2 el alcance máximo del hechizo Agua Estancada."
-            ],
-            "it": [
-              "Aumenta la Portata massima dell'incantesimo Acqua Stagnante di 2"
-            ],
-            "pt": ["Aumenta o alcance máximo do feitiço Água Estagnada em 2"]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": [
-              "Reduces the Aqueous Absorption spell's cooldown period by 1"
-            ],
-            "fr": [
-              "Réduit de 1 le délai de relance du sort Absorption Aqueuse"
-            ],
-            "de": ["Senkt den Cooldown des Zaubers Wässrige Absorption um 1"],
-            "es": [
-              "Reduce en 1 el número de turnos a esperar antes de poder volver a lanzar el hechizo Absorción Acuosa"
-            ],
-            "it": [
-              "Diminuisce di 1 turni l'attesa per il rilancio dell'incantesimo Assorbimento Acquoso"
-            ],
-            "pt": [
-              "Reduz em 1 o intervalo de relançamento do feitiço Absorção Aquosa"
-            ]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Reduces the Miraculous Water spell's AP cost by 1"],
-            "fr": ["Réduit de 1 le coût en PA du sort Eau Miraculeuse"],
-            "de": ["Senkt die AP-Kosten des Zaubers Wunderwasser um 1"],
-            "es": [
-              "Reduce en 1 el número de PA que cuesta el hechizo Agua Bendita."
-            ],
-            "it": [
-              "Diminuisce di 1 il costo di PA dell'incantesimo Acqua Miracolosa"
-            ],
-            "pt": ["Reduz em 1 o custo de PA do feitiço Água Milagrosa"]
-          }
+          "stat": "% Fire Resistance",
+          "value": -5,
+          "altStat": null
         }
       ]
     }
@@ -10954,139 +13075,30 @@
       "en": "Murderous Set",
       "fr": "Panoplie Meurtrière",
       "de": "Mörderisches Set",
-      "es": "Set asesino",
       "it": "Panoplia Omicida",
+      "es": "Set asesino",
       "pt": "Conjunto Assassino"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Agility",
-          "value": 30,
-          "altStat": null
-        },
-        {
           "stat": "Air Damage",
           "value": 10,
           "altStat": null
-        }
-      ],
-      "3": [
-        {
-          "stat": "Agility",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
-          "altStat": null
-        },
-        {
-          "stat": "Air Damage",
-          "value": 10,
-          "altStat": null
-        }
-      ],
-      "4": [
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Reduces the Shaving Foam spell's cooldown period by 1"],
-            "fr": ["Réduit de 1 le délai de relance du sort Mousse à Raser"],
-            "de": ["Senkt den Cooldown des Zaubers Rasierschaum um 1"],
-            "es": [
-              "Reduce en 1 el número de turnos a esperar antes de poder volver a lanzar el hechizo Espuma de afeitar"
-            ],
-            "it": [
-              "Diminuisce di 1 turni l'attesa per il rilancio dell'incantesimo Schiuma da Barba"
-            ],
-            "pt": [
-              "Reduz em 1 o intervalo de relançamento do feitiço Espuma de Barbear"
-            ]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Makes the Ambidexterity spell's range modifiable"],
-            "fr": ["Rend la portée du sort Ambidextrie modifiable"],
-            "de": ["Die Reichweite des Zaubers Ambidextrie wird steigerbar"],
-            "es": ["Vuelve modificable el alcance del hechizo Ambidextreza"],
-            "it": [
-              "Rende modificabile la portata dell'incantesimo Ambidestria"
-            ],
-            "pt": ["Torna possível mudar o alcance do feitiço Ambidestria"]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Increases the Quattro spell's maximum range by 2"],
-            "fr": ["Augmente la portée maximale du sort Quattro de 2"],
-            "de": [
-              "Erhöht die maximale Reichweite des Zauberspruchs Quattro um 2."
-            ],
-            "es": ["Aumenta en 2 el alcance máximo del hechizo Cuattro."],
-            "it": ["Aumenta la Portata massima dell'incantesimo Quattro di 2"],
-            "pt": ["Aumenta o alcance máximo do feitiço Quattro em 2"]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Reduces the Dual-blade spell's cooldown period by 1"],
-            "fr": ["Réduit de 1 le délai de relance du sort Double-lame"],
-            "de": ["Senkt den Cooldown des Zaubers Doppelklinge um 1"],
-            "es": [
-              "Reduce en 1 el número de turnos a esperar antes de poder volver a lanzar el hechizo Doble-filo"
-            ],
-            "it": [
-              "Diminuisce di 1 turni l'attesa per il rilancio dell'incantesimo Doppia-Lama"
-            ],
-            "pt": [
-              "Reduz em 1 o intervalo de relançamento do feitiço Lâmina Dupla"
-            ]
-          }
-        },
-        {
-          "stat": null,
-          "value": null,
-          "altStat": {
-            "en": ["Reduces the Wild Stampede spell's AP cost by 1"],
-            "fr": ["Réduit de 1 le coût en PA du sort Ruée Sauvage"],
-            "de": ["Senkt die AP-Kosten des Zaubers Wilder Ansturm um 1"],
-            "es": [
-              "Reduce en 1 el número de PA que cuesta el hechizo Avalancha Salvaje."
-            ],
-            "it": [
-              "Diminuisce di 1 il costo di PA dell'incantesimo Calata Selvaggia"
-            ],
-            "pt": ["Reduz em 1 o custo de PA do feitiço Dispersão Selvagem"]
-          }
         },
         {
           "stat": "Agility",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Air Damage",
-          "value": 10,
+          "stat": "% Earth Resistance",
+          "value": -5,
           "altStat": null
         },
         {
           "stat": "% Air Resistance",
-          "value": 15,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
+          "value": 5,
           "altStat": null
         }
       ]
@@ -28760,14 +30772,14 @@
       "en": "Tomb Set",
       "fr": "Panoplie des Tombeaux",
       "de": "Grabmal-Set",
-      "es": "Set de las tumbas",
       "it": "Panoplia delle Tombe",
+      "es": "Set de las tumbas",
       "pt": "Conjunto das Tumbas"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Fire Resistance",
+          "stat": "Neutral Resistance",
           "value": 20,
           "altStat": null
         },
@@ -28777,7 +30789,7 @@
           "altStat": null
         },
         {
-          "stat": "Neutral Resistance",
+          "stat": "Water Resistance",
           "value": 20,
           "altStat": null
         },
@@ -28787,14 +30799,19 @@
           "altStat": null
         },
         {
-          "stat": "Water Resistance",
+          "stat": "Fire Resistance",
           "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Fire Resistance",
+          "stat": "Neutral Resistance",
           "value": 20,
           "altStat": null
         },
@@ -28804,7 +30821,7 @@
           "altStat": null
         },
         {
-          "stat": "Neutral Resistance",
+          "stat": "Water Resistance",
           "value": 20,
           "altStat": null
         },
@@ -28814,13 +30831,14 @@
           "altStat": null
         },
         {
-          "stat": "Water Resistance",
+          "stat": "Fire Resistance",
           "value": 20,
           "altStat": null
         },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Intelligence",
+          "value": 30,
           "altStat": null
         }
       ]
@@ -28832,15 +30850,15 @@
       "en": "Mist Set",
       "fr": "Panoplie de Brume",
       "de": "Nebel-Set",
-      "es": "Set de bruma",
       "it": "Panoplia di Bruma",
+      "es": "Set de bruma",
       "pt": "Conjunto de Bruma"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "AP Reduction",
-          "value": 5,
+          "stat": "Strength",
+          "value": 20,
           "altStat": null
         },
         {
@@ -28849,29 +30867,29 @@
           "altStat": null
         },
         {
-          "stat": "Strength",
+          "stat": "Intelligence",
           "value": 20,
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 20,
+          "stat": "AP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "AP Reduction",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Chance",
+          "stat": "Strength",
           "value": 20,
           "altStat": null
         },
         {
-          "stat": "Strength",
+          "stat": "Chance",
           "value": 20,
           "altStat": null
         },
@@ -28881,8 +30899,14 @@
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "AP Reduction",
+          "value": 10,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Lock",
+          "value": 10,
           "altStat": null
         }
       ]
@@ -28893,16 +30917,16 @@
     "name": {
       "en": "Wukin Set",
       "fr": "Panoplie du Wukin",
-      "de": "Wukin Set",
-      "es": "Wukin Set",
-      "it": "Wukin Set",
-      "pt": "Wukin Set"
+      "de": "Wukin-Set",
+      "it": "Panoplia del Wukin",
+      "es": "Set del wukin",
+      "pt": "Conjunto do Wukin"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "AP Reduction",
-          "value": 10,
+          "stat": "Intelligence",
+          "value": 40,
           "altStat": null
         },
         {
@@ -28911,17 +30935,23 @@
           "altStat": null
         },
         {
-          "stat": "Intelligence",
-          "value": 40,
+          "stat": "MP Reduction",
+          "value": -10,
           "altStat": null
         },
         {
-          "stat": "MP Reduction",
-          "value": -10,
+          "stat": "AP Reduction",
+          "value": 10,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "MP", "value": 1, "altStat": null },
+        {
+          "stat": "MP Reduction",
+          "value": -10,
+          "altStat": null
+        },
         {
           "stat": "AP Reduction",
           "value": 10,
@@ -28938,13 +30968,8 @@
           "altStat": null
         },
         {
-          "stat": "MP Reduction",
-          "value": -10,
-          "altStat": null
-        },
-        {
-          "stat": "MP",
-          "value": 1,
+          "stat": "Pushback Damage",
+          "value": 60,
           "altStat": null
         }
       ]
@@ -28955,16 +30980,16 @@
     "name": {
       "en": "Wukang Set",
       "fr": "Panoplie du Wukang",
-      "de": "Wukang Set",
-      "es": "Wukang Set",
-      "it": "Wukang Set",
-      "pt": "Wukang Set"
+      "de": "Wukang-Set",
+      "it": "Panoplia del Wukang",
+      "es": "Set del wukang",
+      "pt": "Conjunto do Wukang"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Strength",
-          "value": 40,
+          "stat": "MP Reduction",
+          "value": 10,
           "altStat": null
         },
         {
@@ -28973,17 +30998,23 @@
           "altStat": null
         },
         {
-          "stat": "MP Reduction",
-          "value": 10,
+          "stat": "Agility",
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Agility",
+          "stat": "Strength",
           "value": 40,
           "altStat": null
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
+        {
+          "stat": "Agility",
+          "value": 40,
+          "altStat": null
+        },
         {
           "stat": "Strength",
           "value": 40,
@@ -29000,13 +31031,8 @@
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Pushback Damage",
+          "value": 60,
           "altStat": null
         }
       ]
@@ -29016,49 +31042,44 @@
     "id": "983465221000031",
     "name": {
       "en": "Wulan Set",
-      "fr": "Panoplie du Wulan",
-      "de": "Wulan Set",
-      "es": "Wulan Set",
-      "it": "Wulan Set",
-      "pt": "Wulan Set"
+      "fr": "Panoplie de Wulan",
+      "de": "Wulan-Set",
+      "it": "Panoplia di Wulan",
+      "es": "Set de Wulán",
+      "pt": "Conjunto de Wulan"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Critical Damage",
-          "value": 15,
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "MP Reduction",
           "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 15,
           "altStat": null
         }
       ],
       "3": [
         {
-          "stat": "Critical Damage",
-          "value": 15,
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Chance",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
@@ -29067,10 +31088,11 @@
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Critical Damage",
+          "value": 15,
           "altStat": null
-        }
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -29080,25 +31102,25 @@
       "en": "Possessed Set",
       "fr": "Panoplie Possédée",
       "de": "Set der Besessenen",
-      "es": "Set de los Poseídos",
       "it": "Panoplia Posseduta",
+      "es": "Set de los poseídos",
       "pt": "Conjunto Possuído"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "MP Reduction",
-          "value": 10,
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Strength",
-          "value": 30,
+          "stat": "MP Reduction",
+          "value": 10,
           "altStat": null
         },
         {
@@ -29109,18 +31131,18 @@
       ],
       "3": [
         {
-          "stat": "MP Reduction",
-          "value": 10,
+          "stat": "Strength",
+          "value": 40,
           "altStat": null
         },
         {
           "stat": "Agility",
-          "value": 30,
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Strength",
-          "value": 30,
+          "stat": "MP Reduction",
+          "value": 10,
           "altStat": null
         },
         {
@@ -29128,11 +31150,7 @@
           "value": 20,
           "altStat": null
         },
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        }
+        { "stat": "AP", "value": 1, "altStat": null }
       ]
     }
   },
@@ -29142,25 +31160,25 @@
       "en": "Pandamonium Set",
       "fr": "Panoplie du Pandamonium",
       "de": "Set des Pandamoniums",
-      "es": "Set de Pandamonium",
       "it": "Panoplia del Pandamonium",
+      "es": "Set de Pandamonium",
       "pt": "Conjunto do Pandamonium"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Heals",
-          "value": 40,
+          "stat": "Strength",
+          "value": 50,
           "altStat": null
         },
         {
           "stat": "Dodge",
-          "value": 5,
+          "value": 10,
           "altStat": null
         },
         {
-          "stat": "Strength",
-          "value": 30,
+          "stat": "Heals",
+          "value": 60,
           "altStat": null
         },
         {
@@ -29170,19 +31188,10 @@
         }
       ],
       "3": [
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "Heals",
-          "value": 40,
-          "altStat": null
-        },
-        {
-          "stat": "Dodge",
-          "value": 5,
-          "altStat": null
-        },
-        {
-          "stat": "Strength",
-          "value": 30,
+          "value": 60,
           "altStat": null
         },
         {
@@ -29191,8 +31200,13 @@
           "altStat": null
         },
         {
-          "stat": "AP",
-          "value": 1,
+          "stat": "Dodge",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 50,
           "altStat": null
         }
       ]
@@ -29632,20 +31646,20 @@
       "en": "Destroyers Set",
       "fr": "Panoplie des Ravageurs",
       "de": "Zerstörer-Set",
-      "es": "Set de Devastador",
       "it": "Panoplia dei Devastatori",
+      "es": "Set de devastador",
       "pt": "Conjunto dos Devastadores"
     },
     "bonuses": {
       "2": [
         {
-          "stat": "Chance",
-          "value": 30,
+          "stat": "Agility",
+          "value": 40,
           "altStat": null
         },
         {
-          "stat": "Agility",
-          "value": 30,
+          "stat": "Chance",
+          "value": 40,
           "altStat": null
         },
         {
@@ -29660,21 +31674,7 @@
         }
       ],
       "3": [
-        {
-          "stat": "Chance",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "Agility",
-          "value": 30,
-          "altStat": null
-        },
-        {
-          "stat": "AP",
-          "value": 1,
-          "altStat": null
-        },
+        { "stat": "AP", "value": 1, "altStat": null },
         {
           "stat": "MP Parry",
           "value": 10,
@@ -29683,6 +31683,16 @@
         {
           "stat": "Pushback Damage",
           "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 40,
           "altStat": null
         }
       ]
@@ -29927,109 +31937,449 @@
       "en": "Cire Momore's Curse",
       "fr": "Malédiction de Cire Momore",
       "de": "Fluch von Cire Momore",
-      "es": "Maldición de Cire Momore",
       "it": "Maledizione di Cire Momore",
+      "es": "Maldición de Cire Momore",
       "pt": "Maldição de Cire Momore"
     },
     "bonuses": {
       "2": [
-        { "stat": "Power", "value": 30, "altStat": null },
-        { "stat": "Range", "value": -1, "altStat": null },
-        { "stat": "Initiative", "value": 300, "altStat": null },
-        { "stat": "Lock", "value": 7, "altStat": null },
-        { "stat": "Dodge", "value": -10, "altStat": null },
-        { "stat": "MP Parry", "value": 25, "altStat": null },
-        { "stat": "Pushback Resistance", "value": 10, "altStat": null },
-        { "stat": "% Neutral Resistance", "value": 3, "altStat": null },
-        { "stat": "% Earth Resistance", "value": 3, "altStat": null },
-        { "stat": "% Fire Resistance", "value": 3, "altStat": null },
-        { "stat": "% Water Resistance", "value": 3, "altStat": null },
-        { "stat": "% Air Resistance", "value": 3, "altStat": null },
-        { "stat": "Neutral Resistance", "value": 25, "altStat": null },
-        { "stat": "Earth Resistance", "value": 25, "altStat": null },
-        { "stat": "Fire Resistance", "value": 25, "altStat": null },
-        { "stat": "Water Resistance", "value": 25, "altStat": null },
-        { "stat": "Air Resistance", "value": 25, "altStat": null }
+        {
+          "stat": "Range",
+          "value": -1,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Air Resistance",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Resistance",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Water Resistance",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Resistance",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 3,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 3,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 3,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 3,
+          "altStat": null
+        },
+        {
+          "stat": "% Neutral Resistance",
+          "value": 3,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 300,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": -10,
+          "altStat": null
+        }
       ],
       "3": [
-        { "stat": "Power", "value": 75, "altStat": null },
         { "stat": "AP", "value": 1, "altStat": null },
-        { "stat": "Range", "value": -2, "altStat": null },
-        { "stat": "Initiative", "value": 750, "altStat": null },
-        { "stat": "Lock", "value": 15, "altStat": null },
-        { "stat": "Dodge", "value": -25, "altStat": null },
-        { "stat": "MP Parry", "value": 50, "altStat": null },
-        { "stat": "Pushback Resistance", "value": 25, "altStat": null },
-        { "stat": "% Neutral Resistance", "value": 5, "altStat": null },
-        { "stat": "% Earth Resistance", "value": 5, "altStat": null },
-        { "stat": "% Fire Resistance", "value": 5, "altStat": null },
-        { "stat": "% Water Resistance", "value": 5, "altStat": null },
-        { "stat": "% Air Resistance", "value": 5, "altStat": null },
-        { "stat": "Neutral Resistance", "value": 50, "altStat": null },
-        { "stat": "Earth Resistance", "value": 50, "altStat": null },
-        { "stat": "Fire Resistance", "value": 50, "altStat": null },
-        { "stat": "Water Resistance", "value": 50, "altStat": null },
-        { "stat": "Air Resistance", "value": 50, "altStat": null }
+        {
+          "stat": "Lock",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Air Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Water Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 4,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 4,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 4,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 4,
+          "altStat": null
+        },
+        {
+          "stat": "% Neutral Resistance",
+          "value": 4,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 500,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": -20,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": -2,
+          "altStat": null
+        }
       ],
       "4": [
-        { "stat": "Power", "value": 75, "altStat": null },
-        { "stat": "AP", "value": 1, "altStat": null },
-        { "stat": "Range", "value": -2, "altStat": null },
-        { "stat": "Initiative", "value": 750, "altStat": null },
-        { "stat": "Lock", "value": 15, "altStat": null },
-        { "stat": "Dodge", "value": -25, "altStat": null },
-        { "stat": "MP Parry", "value": 50, "altStat": null },
-        { "stat": "Pushback Resistance", "value": 25, "altStat": null },
-        { "stat": "% Neutral Resistance", "value": 5, "altStat": null },
-        { "stat": "% Earth Resistance", "value": 5, "altStat": null },
-        { "stat": "% Fire Resistance", "value": 5, "altStat": null },
-        { "stat": "% Water Resistance", "value": 5, "altStat": null },
-        { "stat": "% Air Resistance", "value": 5, "altStat": null },
-        { "stat": "Neutral Resistance", "value": 50, "altStat": null },
-        { "stat": "Earth Resistance", "value": 50, "altStat": null },
-        { "stat": "Fire Resistance", "value": 50, "altStat": null },
-        { "stat": "Water Resistance", "value": 50, "altStat": null },
-        { "stat": "Air Resistance", "value": 50, "altStat": null }
+        {
+          "stat": "Range",
+          "value": -2,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": -25,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 750,
+          "altStat": null
+        },
+        {
+          "stat": "% Neutral Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 5,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Water Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 75,
+          "altStat": null
+        },
+        {
+          "stat": "Air Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 25,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 15,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ],
       "5": [
-        { "stat": "Power", "value": 75, "altStat": null },
-        { "stat": "AP", "value": 1, "altStat": null },
-        { "stat": "Range", "value": -2, "altStat": null },
-        { "stat": "Initiative", "value": 750, "altStat": null },
-        { "stat": "Lock", "value": 15, "altStat": null },
-        { "stat": "Dodge", "value": -25, "altStat": null },
-        { "stat": "MP Parry", "value": 50, "altStat": null },
-        { "stat": "Pushback Resistance", "value": 25, "altStat": null },
-        { "stat": "% Neutral Resistance", "value": 5, "altStat": null },
-        { "stat": "% Earth Resistance", "value": 5, "altStat": null },
-        { "stat": "% Fire Resistance", "value": 5, "altStat": null },
-        { "stat": "% Water Resistance", "value": 5, "altStat": null },
-        { "stat": "% Air Resistance", "value": 5, "altStat": null },
-        { "stat": "Neutral Resistance", "value": 50, "altStat": null },
-        { "stat": "Earth Resistance", "value": 50, "altStat": null },
-        { "stat": "Fire Resistance", "value": 50, "altStat": null },
-        { "stat": "Water Resistance", "value": 50, "altStat": null },
-        { "stat": "Air Resistance", "value": 50, "altStat": null }
+        {
+          "stat": "Range",
+          "value": -2,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": -35,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 1000,
+          "altStat": null
+        },
+        {
+          "stat": "% Neutral Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 7,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 75,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Resistance",
+          "value": 75,
+          "altStat": null
+        },
+        {
+          "stat": "Water Resistance",
+          "value": 75,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Resistance",
+          "value": 75,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Air Resistance",
+          "value": 75,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 35,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 75,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 20,
+          "altStat": null
+        },
+        { "stat": "AP", "value": 1, "altStat": null }
       ],
       "6": [
-        { "stat": "Power", "value": 150, "altStat": null },
         { "stat": "AP", "value": 1, "altStat": null },
-        { "stat": "Range", "value": -3, "altStat": null },
-        { "stat": "Initiative", "value": 1500, "altStat": null },
-        { "stat": "Lock", "value": 30, "altStat": null },
-        { "stat": "Dodge", "value": -50, "altStat": null },
-        { "stat": "MP Parry", "value": 100, "altStat": null },
-        { "stat": "Pushback Resistance", "value": 50, "altStat": null },
-        { "stat": "% Neutral Resistance", "value": 10, "altStat": null },
-        { "stat": "% Earth Resistance", "value": 10, "altStat": null },
-        { "stat": "% Fire Resistance", "value": 10, "altStat": null },
-        { "stat": "% Water Resistance", "value": 10, "altStat": null },
-        { "stat": "% Air Resistance", "value": 10, "altStat": null },
-        { "stat": "Neutral Resistance", "value": 100, "altStat": null },
-        { "stat": "Earth Resistance", "value": 100, "altStat": null },
-        { "stat": "Fire Resistance", "value": 100, "altStat": null },
-        { "stat": "Water Resistance", "value": 100, "altStat": null },
-        { "stat": "Air Resistance", "value": 100, "altStat": null }
+        {
+          "stat": "Lock",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "MP Parry",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Resistance",
+          "value": 50,
+          "altStat": null
+        },
+        {
+          "stat": "Power",
+          "value": 150,
+          "altStat": null
+        },
+        {
+          "stat": "Fire Resistance",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Air Resistance",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Water Resistance",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Resistance",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "Neutral Resistance",
+          "value": 100,
+          "altStat": null
+        },
+        {
+          "stat": "% Earth Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Air Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Water Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "% Fire Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": 1500,
+          "altStat": null
+        },
+        {
+          "stat": "% Neutral Resistance",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": -50,
+          "altStat": null
+        },
+        {
+          "stat": "Range",
+          "value": -3,
+          "altStat": null
+        }
       ]
     }
   },
@@ -30139,23 +32489,65 @@
       "en": "Bitter-Hammer Set",
       "fr": "Panoplie des Marteaux-Aigris",
       "de": "Sauerhammer-Set",
-      "es": "Set de los Martilloseco",
       "it": "Panoplia dei Martelli-Rancorosi",
+      "es": "Set de los Martilloseco",
       "pt": "Conjunto dos Martelos Amargos"
     },
     "bonuses": {
       "2": [
-        { "stat": "Strength", "value": 40, "altStat": null },
-        { "stat": "Chance", "value": 40, "altStat": null },
-        { "stat": "Earth Damage", "value": 15, "altStat": null },
-        { "stat": "Water Damage", "value": 15, "altStat": null }
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Lock",
+          "value": 10,
+          "altStat": null
+        }
       ],
       "3": [
-        { "stat": "Strength", "value": 40, "altStat": null },
-        { "stat": "Chance", "value": 40, "altStat": null },
+        {
+          "stat": "Chance",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Water Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Earth Damage",
+          "value": 10,
+          "altStat": null
+        },
         { "stat": "MP", "value": 1, "altStat": null },
-        { "stat": "Earth Damage", "value": 15, "altStat": null },
-        { "stat": "Water Damage", "value": 15, "altStat": null }
+        {
+          "stat": "Lock",
+          "value": 10,
+          "altStat": null
+        }
       ]
     }
   },
@@ -30165,19 +32557,45 @@
       "en": "Berylbell Set",
       "fr": "Panoplie de Barbéryl",
       "de": "Barberyl-Set",
-      "es": "Set de Demena",
       "it": "Panoplia di Barberilla",
+      "es": "Set de Demena",
       "pt": "Conjunto de Barberila"
     },
     "bonuses": {
       "2": [
-        { "stat": "Chance", "value": 40, "altStat": null },
-        { "stat": "Critical Damage", "value": 10, "altStat": null }
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
+        {
+          "stat": "Critical Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 7,
+          "altStat": null
+        }
       ],
       "3": [
-        { "stat": "Chance", "value": 40, "altStat": null },
+        {
+          "stat": "Chance",
+          "value": 40,
+          "altStat": null
+        },
         { "stat": "AP", "value": 1, "altStat": null },
-        { "stat": "Critical Damage", "value": 10, "altStat": null }
+        {
+          "stat": "Critical Damage",
+          "value": 10,
+          "altStat": null
+        },
+        {
+          "stat": "Dodge",
+          "value": 7,
+          "altStat": null
+        }
       ]
     }
   },
@@ -30187,25 +32605,75 @@
       "en": "Copperbeard Set",
       "fr": "Panoplie Clochecuivre",
       "de": "Glockenleder-Set",
-      "es": "Set Decobre",
       "it": "Panoplia Rametista",
+      "es": "Set Decobre",
       "pt": "Conjunto Sinocobre"
     },
     "bonuses": {
       "2": [
-        { "stat": "Strength", "value": 30, "altStat": null },
-        { "stat": "Intelligence", "value": 30, "altStat": null },
-        { "stat": "Agility", "value": 30, "altStat": null },
-        { "stat": "Heals", "value": 20, "altStat": null },
-        { "stat": "Pushback Damage", "value": 30, "altStat": null }
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Heals",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Damage",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": -300,
+          "altStat": null
+        }
       ],
       "3": [
-        { "stat": "Strength", "value": 30, "altStat": null },
-        { "stat": "Intelligence", "value": 30, "altStat": null },
-        { "stat": "Agility", "value": 30, "altStat": null },
         { "stat": "AP", "value": 1, "altStat": null },
-        { "stat": "Heals", "value": 20, "altStat": null },
-        { "stat": "Pushback Damage", "value": 30, "altStat": null }
+        {
+          "stat": "Heals",
+          "value": 20,
+          "altStat": null
+        },
+        {
+          "stat": "Pushback Damage",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Intelligence",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Agility",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Strength",
+          "value": 30,
+          "altStat": null
+        },
+        {
+          "stat": "Initiative",
+          "value": -300,
+          "altStat": null
+        }
       ]
     }
   }

--- a/server/app/database/data/weapons.json
+++ b/server/app/database/data/weapons.json
@@ -8702,9 +8702,9 @@
             "value": 6
           },
           {
-            "stat": "WISDOM",
-            "operator": ">",
-            "value": 350
+            "stat": "MP",
+            "operator": "<",
+            "value": 12
           }
         ]
       },
@@ -26374,7 +26374,7 @@
     },
     "itemType": "Sword",
     "level": 100,
-    "setID": "266",
+    "setID": null,
     "stats": [],
     "weaponStats": {
       "apCost": 5,
@@ -26432,7 +26432,7 @@
     },
     "itemType": "Shovel",
     "level": 100,
-    "setID": "267",
+    "setID": null,
     "stats": [],
     "weaponStats": {
       "apCost": 4,
@@ -26495,7 +26495,7 @@
     },
     "itemType": "Hammer",
     "level": 100,
-    "setID": "268",
+    "setID": null,
     "stats": [],
     "weaponStats": {
       "apCost": 6,
@@ -26553,7 +26553,7 @@
     },
     "itemType": "Dagger",
     "level": 100,
-    "setID": "269",
+    "setID": null,
     "stats": [],
     "weaponStats": {
       "apCost": 3,


### PR DESCRIPTION
Here the changes from 2.70 related to sets

There were a bit of collateral damages from the set updates + the new Dofus so note that the scripts have to be ran correctly :)

For `items.json`: 
- All borealis items, all professor Xa's items and Celestial Bearbarian Amulet changed effects, 
- Will Kilson, Mandrin, Styx, Inferno are not associated to any sets anymore
- Sylvan Dofus was added

For `pets.json`:
- Brockheart, Kanigloopy, Bulbisou, Teddybearbarian are not associated to any sets anymore

For `buffs.json`:
- Added Sylvan dofus effect

If possible, test the changes before, since I really did not have time to do more than edit the JSON :(