### PR TITLE
fix: resolves issue with two migrations pointing to the same down_revision

### DIFF
--- a/server/app/migrations/versions/f175244278d9_.py
+++ b/server/app/migrations/versions/f175244278d9_.py
@@ -1,7 +1,7 @@
 """empty message
 
 Revision ID: f175244278d9
-Revises: b9b68fd74d2a
+Revises: e754dc048376
 Create Date: 2024-03-12 10:02:28.673183
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "f175244278d9"
-down_revision = "b9b68fd74d2a"
+down_revision = "e754dc048376"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Context

This migration will now point to the right `down_revision` so there's no clashes in migrations.