### PR TITLE
fixes KeyError on sync_item

### DIFF
--- a/server/oneoff/sync_item.py
+++ b/server/oneoff/sync_item.py
@@ -34,7 +34,7 @@ def update_or_create_item(
     new_items_list=[],
 ):
     print("[{}]: {}".format(item_id, record["name"]["en"]))
-    if record["mountDofusID"]:
+    if "mountDofusID" in record:
         database_item = (
             db_session.query(ModelItem)
             .filter(ModelItem.dofus_db_mount_id == item_id)


### PR DESCRIPTION
## Context

`sync_item` was throwing an error because the existence of a key for a record was being checked incorrectly.