### PR TITLE
Fix notifs and modals

### DIFF
--- a/client/common/notificationContext.ts
+++ b/client/common/notificationContext.ts
@@ -1,0 +1,9 @@
+import { notification } from 'antd';
+import { NotificationInstance } from 'antd/lib/notification/interface';
+import { createContext } from 'react';
+
+const NotificationContext = createContext<
+  NotificationInstance | typeof notification
+>(notification);
+
+export default NotificationContext;

--- a/client/common/utils.tsx
+++ b/client/common/utils.tsx
@@ -12,7 +12,7 @@ import {
 } from '@apollo/client';
 import { useRouter, NextRouter } from 'next/router';
 
-import { notification } from 'antd';
+import { notification } from 'components/common/StaticFunctions';
 import cloneDeep from 'lodash/cloneDeep';
 import groupBy from 'lodash/groupBy';
 import { useTranslation, Trans } from 'next-i18next';
@@ -73,6 +73,7 @@ import {
 } from 'graphql/mutations/__generated__/toggleFavoriteItem';
 import toggleFavoriteItemMutation from 'graphql/mutations/toggleFavoriteItem.graphql';
 import { DefaultOptionType } from 'antd/lib/select';
+
 import {
   StatsFromCustomSet,
   SetCounter,

--- a/client/components/common/AddBuffLink.tsx
+++ b/client/components/common/AddBuffLink.tsx
@@ -9,7 +9,7 @@ import { Badge } from 'common/wrappers';
 import { blue6, blue8 } from 'common/mixins';
 import { statIcons } from 'common/constants';
 import { CustomSetContext, getImageUrl } from 'common/utils';
-import { notification } from 'antd';
+import NotificationContext from 'common/notificationContext';
 
 interface Props {
   buff: Buff;
@@ -22,6 +22,7 @@ interface Props {
 const AddBuffLink = ({ buff, isCrit, spell, item, shouldNotify }: Props) => {
   const buffName = spell?.name || item?.name || '';
   const { appliedBuffs, dispatch } = useContext(CustomSetContext);
+  const notificationApi = useContext(NotificationContext);
   const key = isCrit ? 'critIncrementBy' : 'incrementBy';
   const { t } = useTranslation(['stat', 'common', 'weapon_spell_effect']);
 
@@ -34,7 +35,7 @@ const AddBuffLink = ({ buff, isCrit, spell, item, shouldNotify }: Props) => {
 
   const onAddBuff = useCallback(() => {
     if (maxStacksApplied) {
-      notification.error({
+      notificationApi.error({
         message: t('ERROR', { ns: 'common' }),
         description: t('MAX_STACKS_APPLIED', { ns: 'weapon_spell_effect' }),
       });
@@ -48,7 +49,7 @@ const AddBuffLink = ({ buff, isCrit, spell, item, shouldNotify }: Props) => {
       item,
     });
     if (shouldNotify) {
-      notification.success({
+      notificationApi.success({
         message: t('SUCCESS', { ns: 'common' }),
         description: t('BUFF_APPLY_SUCCESS', { ns: 'common', buffName }),
       });
@@ -57,7 +58,7 @@ const AddBuffLink = ({ buff, isCrit, spell, item, shouldNotify }: Props) => {
 
   const onAddMax = useCallback(() => {
     if (maxStacksApplied) {
-      notification.error({
+      notificationApi.error({
         message: t('ERROR', { ns: 'common' }),
         description: t('MAX_STACKS_APPLIED', { ns: 'weapon_spell_effect' }),
       });
@@ -71,7 +72,7 @@ const AddBuffLink = ({ buff, isCrit, spell, item, shouldNotify }: Props) => {
       item,
     });
     if (shouldNotify) {
-      notification.success({
+      notificationApi.success({
         message: t('SUCCESS', { ns: 'common' }),
         description: t('BUFF_APPLY_SUCCESS', { ns: 'common', buffName }),
       });

--- a/client/components/common/BuffModal.tsx
+++ b/client/components/common/BuffModal.tsx
@@ -1,14 +1,13 @@
 /** @jsxImportSource @emotion/react */
 
 import { useContext, useState, useCallback } from 'react';
-import Modal from 'antd/lib/modal/Modal';
 
 import { AppliedBuff, AppliedBuffActionType } from 'common/types';
 import { useTranslation } from 'next-i18next';
 import { useQuery } from '@apollo/client';
 import { classes } from 'graphql/queries/__generated__/classes';
 import classesQuery from 'graphql/queries/classes.graphql';
-import { Select, Divider, Button } from 'antd';
+import { Select, Divider, Button, Modal } from 'antd';
 import {
   antdSelectFilterOption,
   CustomSetContext,

--- a/client/components/common/ChangePasswordModal.tsx
+++ b/client/components/common/ChangePasswordModal.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @emotion/react */
 
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 
-import { Button, Form, Input, Modal, notification } from 'antd';
+import { Button, Form, Input, Modal } from 'antd';
 
 import { useMutation, useApolloClient } from '@apollo/client';
 import { useTranslation } from 'next-i18next';
@@ -13,6 +13,7 @@ import {
 import changePasswordMutation from 'graphql/mutations/changePassword.graphql';
 import { PASSWORD_REGEX } from 'common/constants';
 import { inputFontSize } from 'common/mixins';
+import NotificationContext from 'common/notificationContext';
 
 interface Props {
   open: boolean;
@@ -28,6 +29,9 @@ const ChangePasswordModal = ({ open, onClose }: Props) => {
     ChangePassword,
     ChangePasswordVariables
   >(changePasswordMutation);
+
+  const notificationApi = useContext(NotificationContext);
+
   const handleOk = useCallback(async () => {
     const values = await form.validateFields();
 
@@ -40,7 +44,7 @@ const ChangePasswordModal = ({ open, onClose }: Props) => {
     if (data?.changePassword?.ok) {
       form.resetFields();
       onClose();
-      notification.success({ message: t('PASSWORD_CHANGE_SUCCESS') });
+      notificationApi.success({ message: t('PASSWORD_CHANGE_SUCCESS') });
     }
   }, [changePassword, onClose, client, form]);
 

--- a/client/components/common/DeleteCustomSetModal.tsx
+++ b/client/components/common/DeleteCustomSetModal.tsx
@@ -2,8 +2,8 @@
 
 import type { MouseEvent } from 'react';
 
-import { useCallback } from 'react';
-import { Modal, notification } from 'antd';
+import { useCallback, useContext } from 'react';
+import { Modal } from 'antd';
 import { useMutation } from '@apollo/client';
 import { useRouter } from 'next/router';
 
@@ -13,6 +13,7 @@ import {
   deleteCustomSetVariables,
 } from 'graphql/mutations/__generated__/deleteCustomSet';
 import deleteCustomSetMutation from 'graphql/mutations/deleteCustomSet.graphql';
+import NotificationContext from 'common/notificationContext';
 
 interface Props {
   open: boolean;
@@ -22,6 +23,7 @@ interface Props {
 
 const DeleteCustomSetModal = ({ open, onCancel, customSetId }: Props) => {
   const { t } = useTranslation('common');
+  const notificationApi = useContext(NotificationContext);
   const [deleteMutate, { loading: deleteLoading }] = useMutation<
     deleteCustomSet,
     deleteCustomSetVariables
@@ -41,7 +43,7 @@ const DeleteCustomSetModal = ({ open, onCancel, customSetId }: Props) => {
         if (customSetId === router.query.customSetId) {
           router.push('/', '/', { shallow: true });
         }
-        notification.success({
+        notificationApi.success({
           message: t('SUCCESS'),
           description: t('DELETE_BUILD_SUCCESS'),
         });

--- a/client/components/common/ItemCard.tsx
+++ b/client/components/common/ItemCard.tsx
@@ -2,7 +2,7 @@
 
 import type { SetStateAction, Dispatch, MouseEvent } from 'react';
 
-import { useCallback, memo } from 'react';
+import { useCallback, memo, useContext } from 'react';
 
 import {
   slotToUrlString,
@@ -15,13 +15,13 @@ import { useApolloClient, useQuery } from '@apollo/client';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import ItemSlotsQuery from 'graphql/queries/itemSlots.graphql';
 import { ItemSlot, ItemSet, Item } from 'common/type-aliases';
-import { notification } from 'antd';
 import { useTranslation } from 'next-i18next';
 import { currentUser as CurrentUserQueryType } from 'graphql/queries/__generated__/currentUser';
 import currentUserQuery from 'graphql/queries/currentUser.graphql';
 import { faHeart as faHeartSolid } from '@fortawesome/free-solid-svg-icons';
 import { faHeart as faHeartRegular } from '@fortawesome/free-regular-svg-icons';
 import { prependDe } from 'common/i18n-utils';
+import NotificationContext from 'common/notificationContext';
 
 import BasicItemCard from './BasicItemCard';
 
@@ -53,7 +53,7 @@ const ItemCard = ({
   const mutate = useEquipItemMutation(item);
   const { t, i18n } = useTranslation('common');
   const client = useApolloClient();
-
+  const notificationApi = useContext(NotificationContext);
   const router = useRouter();
   const { data } = useQuery<CurrentUserQueryType>(currentUserQuery);
 
@@ -85,7 +85,7 @@ const ItemCard = ({
       }
 
       const notify = (slot: ItemSlot | null) =>
-        notification.success({
+        notificationApi.success({
           message: t('SUCCESS'),
           description: slot
             ? t('ITEM_EQUIPPED_WITH_SLOT', {

--- a/client/components/common/ProfilePictureModal.tsx
+++ b/client/components/common/ProfilePictureModal.tsx
@@ -2,9 +2,9 @@
 
 import type { MouseEvent } from 'react';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
-import { Divider, Modal, notification } from 'antd';
+import { Divider, Modal } from 'antd';
 import { useTheme } from '@emotion/react';
 import { useRouter } from 'next/router';
 
@@ -16,7 +16,8 @@ import {
   changeProfilePictureVariables,
 } from 'graphql/mutations/__generated__/changeProfilePicture';
 import { useMutation } from '@apollo/client';
-import { PROFILE_PICTURES, mq } from '../../common/constants';
+import { PROFILE_PICTURES, mq } from 'common/constants';
+import NotificationContext from 'common/notificationContext';
 
 interface Props {
   open: boolean;
@@ -37,14 +38,14 @@ const ProfilePictureModal = ({ onCancel, open, currentlyActive }: Props) => {
     awaitRefetchQueries: true,
   });
   const router = useRouter();
-
+  const notificationApi = useContext(NotificationContext);
   const onChangePicture = useCallback(
     async (e: MouseEvent<HTMLElement>) => {
       e.stopPropagation();
       const { data } = await profilePictureMutate();
       onCancel();
       if (data?.changeProfilePicture?.user?.profilePicture) {
-        notification.success({
+        notificationApi.success({
           message: t('SUCCESS'),
           description: t('CHANGE_PICTURE_SUCCESS'),
         });

--- a/client/components/common/RequestPasswordResetModal.tsx
+++ b/client/components/common/RequestPasswordResetModal.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @emotion/react */
 
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 
-import { Modal, Input, Form, Button, notification } from 'antd';
+import { Modal, Input, Form, Button } from 'antd';
 import { useMutation } from '@apollo/client';
 import { useTranslation } from 'next-i18next';
 import { mq } from 'common/constants';
@@ -12,6 +12,7 @@ import {
 } from 'graphql/mutations/__generated__/requestPasswordReset';
 import requestPasswordResetMutation from 'graphql/mutations/requestPasswordReset.graphql';
 import { inputFontSize } from 'common/mixins';
+import NotificationContext from 'common/notificationContext';
 
 interface Props {
   open: boolean;
@@ -26,6 +27,7 @@ const RequestPasswordResetModal = ({ open, onClose }: Props) => {
     requestPasswordReset,
     requestPasswordResetVariables
   >(requestPasswordResetMutation);
+  const notificationApi = useContext(NotificationContext);
   const handleOk = useCallback(async () => {
     const values = await form.validateFields();
 
@@ -36,7 +38,7 @@ const RequestPasswordResetModal = ({ open, onClose }: Props) => {
     });
     if (data?.requestPasswordReset?.ok) {
       onClose();
-      notification.success({
+      notificationApi.success({
         message: t('REQUEST_PASSWORD_RESET_EMAIL_SENT.TITLE'),
         description: t('REQUEST_PASSWORD_RESET_EMAIL_SENT.DESCRIPTION'),
       });

--- a/client/components/common/SpellCardContent.tsx
+++ b/client/components/common/SpellCardContent.tsx
@@ -2,7 +2,7 @@
 
 import { useContext, useState, useCallback, Fragment } from 'react';
 
-import { Divider, notification, Select, Radio } from 'antd';
+import { Divider, Select, Radio } from 'antd';
 import { useTheme } from '@emotion/react';
 
 import {
@@ -30,6 +30,8 @@ import {
 } from 'common/types';
 import { Stat } from '__generated__/globalTypes';
 import { CustomSet, Spell, SpellEffect } from 'common/type-aliases';
+import NotificationContext from 'common/notificationContext';
+
 import AddBuffLink from './AddBuffLink';
 
 interface Props {
@@ -64,6 +66,8 @@ const SpellCardContent = ({ spell, selectedSpellLevelIdx }: Props) => {
     spellStats?.spellEffects.find((e) => !!e.condition)?.condition ?? null,
   );
 
+  const notificationApi = useContext(NotificationContext);
+
   const totalDamageIncrease = baseDamageIncreases.reduce(
     (acc, curr) => acc + curr,
     0,
@@ -91,7 +95,7 @@ const SpellCardContent = ({ spell, selectedSpellLevelIdx }: Props) => {
           baseDamageIncreases.length >=
             spellStats.spellDamageIncrease.maxStacks)
       ) {
-        notification.error({
+        notificationApi.error({
           message: t('ERROR', { ns: 'common' }),
           description: t('MAX_STACKS_APPLIED'),
         });

--- a/client/components/common/StaticFunctions.tsx
+++ b/client/components/common/StaticFunctions.tsx
@@ -1,0 +1,21 @@
+import { App } from 'antd';
+import type { MessageInstance } from 'antd/es/message/interface';
+import type { ModalStaticFunctions } from 'antd/es/modal/confirm';
+import type { NotificationInstance } from 'antd/es/notification/interface';
+
+// eslint-disable-next-line import/no-mutable-exports
+let message: MessageInstance;
+// eslint-disable-next-line import/no-mutable-exports
+let notification: NotificationInstance;
+// eslint-disable-next-line import/no-mutable-exports
+let modal: Omit<ModalStaticFunctions, 'warn'>;
+
+export default () => {
+  const staticFunction = App.useApp();
+  message = staticFunction.message;
+  modal = staticFunction.modal;
+  notification = staticFunction.notification;
+  return null;
+};
+
+export { message, modal, notification };

--- a/client/components/common/StatusChecker.tsx
+++ b/client/components/common/StatusChecker.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @emotion/react */
 
-import { useCallback, useEffect, memo } from 'react';
+import { useCallback, useEffect, memo, useContext } from 'react';
 import { useRouter } from 'next/router';
-import { notification } from 'antd';
+import NotificationContext from 'common/notificationContext';
 import { useQuery } from '@apollo/client';
 
 import { useTranslation } from 'next-i18next';
@@ -63,12 +63,14 @@ const StatusChecker = () => {
   const { t } = useTranslation('status');
   const { data } = useQuery<currentUser>(currentUserQuery);
 
+  const notificationApi = useContext(NotificationContext);
+
   const processQueryEntry = useCallback(
     (statusType: string, statusValue: string) => {
       const obj = statusMap[statusType]?.[statusValue];
       if (isStatusObj(obj)) {
         const tKey = `${statusMap[statusType].messageKey}.${obj.messageKey}`;
-        notification[obj.type]({
+        notificationApi[obj.type]({
           message: t(`${tKey}.TITLE`),
           description: t(`${tKey}.DESCRIPTION`),
         });

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -33,7 +33,8 @@ import '@fortawesome/fontawesome-svg-core/styles.css';
 import '@ant-design/v5-patch-for-react-19';
 
 import Head from 'next/head';
-import { ConfigProvider, theme } from 'antd';
+import { App, ConfigProvider, notification, theme } from 'antd';
+import NotificationContext from 'common/notificationContext';
 
 Router.events.on('routeChangeComplete', (url) => gtag.pageview(url));
 config.autoAddCss = false;
@@ -78,6 +79,10 @@ const DofusLabApp = ({ Component, apolloClient, pageProps }: Props) => {
     dispatch({ type: AppliedBuffActionType.CLEAR_ALL });
   }, [customSetId]);
 
+  const [api, contextHolder] = notification.useNotification();
+
+  const notificationContextValue = useMemo(() => api, [api]);
+
   const customSetContextValue = useMemo(
     () => ({
       dispatch,
@@ -109,15 +114,20 @@ const DofusLabApp = ({ Component, apolloClient, pageProps }: Props) => {
               algorithm: theme.darkAlgorithm,
             }}
           >
-            <CustomSetContext.Provider value={customSetContextValue}>
-              <Head>
-                <meta
-                  name="viewport"
-                  content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-                />
-              </Head>
-              <Component {...pageProps} />
-            </CustomSetContext.Provider>
+            <App>
+              <CustomSetContext.Provider value={customSetContextValue}>
+                <NotificationContext.Provider value={notificationContextValue}>
+                  <Head>
+                    <meta
+                      name="viewport"
+                      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+                    />
+                  </Head>
+                  {contextHolder}
+                  <Component {...pageProps} />
+                </NotificationContext.Provider>
+              </CustomSetContext.Provider>
+            </App>
           </ConfigProvider>
         </ThemeProvider>
       </MediaContextProvider>

--- a/client/pages/reset-password.tsx
+++ b/client/pages/reset-password.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useContext } from 'react';
 import { GetStaticProps, NextPage } from 'next';
 import { useQuery, useMutation } from '@apollo/client';
 
@@ -9,7 +9,7 @@ import { mediaStyles } from 'components/common/Media';
 import Head from 'next/head';
 import currentUserQuery from 'graphql/queries/currentUser.graphql';
 import { useRouter } from 'next/router';
-import { Button, Form, Input, notification } from 'antd';
+import { Button, Form, Input } from 'antd';
 import { useTranslation } from 'next-i18next';
 import {
   resetPassword,
@@ -23,11 +23,12 @@ import { getImageUrl, getTitle } from 'common/utils';
 import { inputFontSize } from 'common/mixins';
 import { DEFAULT_LANGUAGE } from 'common/i18n-utils';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import NotificationContext from 'common/notificationContext';
 
 const RequestPasswordResetPage: NextPage = () => {
   const { data } = useQuery<currentUser>(currentUserQuery);
   const router = useRouter();
-
+  const notificationApi = useContext(NotificationContext);
   const { token } = router.query;
 
   const { t } = useTranslation('auth');
@@ -63,7 +64,7 @@ const RequestPasswordResetPage: NextPage = () => {
     });
     if (resetPasswordData?.resetPassword?.ok) {
       form.resetFields();
-      notification.success({
+      notificationApi.success({
         message: t('RESET_PASSWORD_SUCCESS.TITLE'),
         description: t('RESET_PASSWORD_SUCCESS.DESCRIPTION'),
       });


### PR DESCRIPTION
### TL;DR

Implemented a centralized notification system using React Context API to replace direct Ant Design notification imports.

### What changed?

- Created a new `NotificationContext` to provide a consistent way to access notification functionality
- Added a `StaticFunctions.tsx` component to properly initialize Ant Design's notification API
- Wrapped the application with Ant Design's `App` component and notification context provider
- Updated all components that were using direct `notification` imports to use the context instead
- Integrated with Ant Design's notification API using the new context-based approach

### How to test?

1. Verify that all notifications still appear correctly throughout the application
2. Test notifications in various components:
   - When adding/removing buffs
   - When changing passwords
   - When deleting custom sets
   - When equipping items
   - When changing profile pictures
   - When requesting password resets

### Why make this change?

This change addresses a compatibility issue with Ant Design v5, which recommends using the App context for static methods like notifications. By centralizing notification calls through a context, we ensure consistent behavior across the application and follow Ant Design's best practices for notifications. This approach also makes it easier to mock notifications for testing and provides a single point of control for notification styling and behavior.